### PR TITLE
feat(llm): add Z.ai (GLM) as an OpenAI-compatible provider

### DIFF
--- a/.ai-interactions/tasks/issue-3/output-1_glm-model-plan.md
+++ b/.ai-interactions/tasks/issue-3/output-1_glm-model-plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Support Z.ai GLM Models
+
+## Issue Summary
+GitHub Issue [#3](https://github.com/mochow13/keen-code/issues/3) — GLM models
+from Z.ai are supported through the OpenAI completions API. We can add Z.ai as
+another OpenAI-compatible provider, following the same pattern as DeepSeek and
+MoonshotAI.
+
+Z.ai (ZhipuAI) exposes an OpenAI-compatible Chat Completions endpoint at
+`https://api.z.ai/api/paas/v4/`.
+
+---
+
+## Current Architecture (relevant touch-points)
+
+| Layer | File | Role |
+|---|---|---|
+| Provider constants | `internal/config/config.go` | `ProviderDeepSeek`, `ProviderMoonshotAI`, etc. |
+| Config types | `internal/config/config.go` | `ProviderConfig`, `ResolvedConfig`, `Resolve()` |
+| LLM factory | `internal/llm/models.go` | `NewClient()` dispatches to client constructors |
+| OpenAI-compat client | `internal/llm/openai.go` | `OpenAICompatibleClient`, `openAICompatibleBaseURL()` |
+| Model selection UI | `internal/cli/repl/widgets/model_selection.go` | Provider list shown to user |
+
+---
+
+## Implementation Plan
+
+### 1. Add provider constant
+
+**File:** `internal/config/config.go`
+
+- [ ] Add `ProviderZAI = "zai"` constant alongside the existing providers.
+
+---
+
+### 2. Register Z.ai in the LLM factory
+
+**File:** `internal/llm/models.go`
+
+- [ ] Add `config.ProviderZAI` to the existing `case` that already handles
+      `config.ProviderDeepSeek` and `config.ProviderMoonshotAI`, since all three
+      use `NewOpenAICompatibleClient`:
+
+```go
+case config.ProviderDeepSeek,
+    config.ProviderMoonshotAI,
+    config.ProviderZAI:
+```
+
+No new constructor or client type is needed.
+
+---
+
+### 3. Add default base URL for Z.ai
+
+**File:** `internal/llm/openai.go`
+
+- [ ] Add a case to `openAICompatibleBaseURL()`:
+
+```go
+case Provider(config.ProviderZAI):
+    return "https://api.z.ai/api/paas/v4/", nil
+```
+
+This follows the exact pattern used for DeepSeek and MoonshotAI. When a user has
+configured a custom `base_url` in their provider config, it will already take
+precedence (the `NewOpenAICompatibleClient` constructor checks `cfg.BaseURL`
+first before falling back to `openAICompatibleBaseURL()`).
+
+---
+
+### 4. Surface Z.ai in the model selection UI
+
+**File:** `internal/cli/repl/widgets/model_selection.go`
+
+- [ ] Add Z.ai to the provider list so it appears in the `/model` wizard.
+      Find where providers are listed (the `StepProvider` options) and add an
+      entry for `config.ProviderZAI` with a display name like `"Z.ai (GLM)"`.
+
+---
+
+### 5. Tests
+
+**File:** `internal/llm/openai_test.go`
+
+- [ ] Add test: `openAICompatibleBaseURL` returns the correct URL for
+      `Provider(config.ProviderZAI)`.
+- [ ] Add test: `NewOpenAICompatibleClient` with `ProviderZAI` succeeds and
+      uses the default base URL.
+
+**File:** `internal/llm/models_test.go`
+
+- [ ] Add test: `NewClient` with `config.ProviderZAI` returns a non-nil client
+      (follows existing test pattern if present).
+
+**File:** `internal/config/config_test.go`
+
+- [ ] No changes needed — config is provider-agnostic; existing tests cover the
+      generic `Resolve()` flow.
+
+---
+
+### 6. Housekeeping
+
+- [ ] Run `go test ./...` — all tests pass.
+- [ ] Run `go mod tidy`.
+- [ ] Update `CHANGELOG.md` `[Unreleased]` section:
+      `- feat(llm): add Z.ai (GLM) as an OpenAI-compatible provider (#3)`
+
+---
+
+## File Change Summary
+
+| File | Change type |
+|---|---|
+| `internal/config/config.go` | Edit — add `ProviderZAI` constant |
+| `internal/llm/models.go` | Edit — add `config.ProviderZAI` to existing OpenAI-compat case |
+| `internal/llm/openai.go` | Edit — add Z.ai base URL to `openAICompatibleBaseURL()` |
+| `internal/cli/repl/widgets/model_selection.go` | Edit — add Z.ai to provider list |
+| `internal/llm/openai_test.go` | Edit — add base URL and client creation tests |
+| `CHANGELOG.md` | Edit — add unreleased entry |
+
+---
+
+## Notes
+
+- **No new dependencies required.** Z.ai uses the standard OpenAI Chat
+  Completions API, so the existing `openai-go` SDK handles it.
+- **No new client type needed.** `OpenAICompatibleClient` already supports
+  streaming, tool calling, and `reasoning_content` extraction — all of which
+  work with the Z.ai API.
+- **Reasoning content:** GLM models may or may not support the
+  `reasoning_content` extension field. The existing extraction logic
+  (`extractJSONStringField`) is a no-op when the field is absent, so no
+  special handling is required.
+- **Scope:** This is a minimal, low-risk change — approximately 6 lines of
+  production code across 4 files, plus tests.

--- a/.ai-interactions/tasks/issue-3/prompt-1_glm-model.md
+++ b/.ai-interactions/tasks/issue-3/prompt-1_glm-model.md
@@ -1,0 +1,24 @@
+## Supporing Z.ai GLM Models
+
+1. We have an issue on Github: https://github.com/mochow13/keen-code/issues/3 for supporting Z.ai GLM models. Check the issue for more details. Then create an implementation plan for supporting Z.ai GLM models. Save the plan in the `.ai-interactions/tasks/issue-3/output-1_glm-model-plan.md` file.
+2. For GLM we also need to support thinking. Check this example of a cURL request to the Z.ai GLM API:
+
+```bash
+curl --location 'https://api.z.ai/api/paas/v4/chat/completions' \
+--header 'Authorization: Bearer YOUR_API_KEY' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "glm-5",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Explain in detail the basic principles of quantum computing and analyze its potential impact in the field of cryptography"
+        }
+    ],
+    "thinking": {
+        "type": "enabled"
+    },
+    "max_tokens": 4096,
+    "temperature": 1.0
+}'
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Z.ai (GLM) as an OpenAI-compatible provider (#3)
+
 ## [0.5.0] - 2026-04-23
 
 ### Added

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -904,21 +904,15 @@ func (m *replModel) handleThinkingCommand(input string) (replModel, tea.Cmd) {
 		return *m, nil
 	}
 
-	allowed := append([]string{"off"}, modelMeta.ThinkingEfforts...)
-	if !slices.Contains(allowed, effort) {
-		m.output.AddError("Usage: /thinking "+strings.Join(allowed, "|"), repltheme.ErrorStyle)
+	if !slices.Contains(modelMeta.ThinkingEfforts, effort) {
+		m.output.AddError("Usage: /thinking "+strings.Join(modelMeta.ThinkingEfforts, "|"), repltheme.ErrorStyle)
 		m.updateViewportContent()
 		m.viewport.GotoBottom()
 		return *m, nil
 	}
 
-	storedEffort := effort
-	if effort == "off" {
-		storedEffort = ""
-	}
-
-	m.ctx.cfg.ThinkingEffort = storedEffort
-	m.ctx.globalCfg.ThinkingEffort = storedEffort
+	m.ctx.cfg.ThinkingEffort = effort
+	m.ctx.globalCfg.ThinkingEffort = effort
 	if err := m.ctx.loader.Save(m.ctx.globalCfg); err != nil {
 		m.output.AddError("Failed to save config: "+err.Error(), repltheme.ErrorStyle)
 		m.updateViewportContent()
@@ -933,11 +927,7 @@ func (m *replModel) handleThinkingCommand(input string) (replModel, tea.Cmd) {
 		return *m, nil
 	}
 
-	display := effort
-	if display == "off" {
-		display = "off (disabled)"
-	}
-	m.output.AddStyledLine("  ✓ Thinking effort set to: "+display, repltheme.HighlightStyle)
+	m.output.AddStyledLine("  ✓ Thinking effort set to: "+effort, repltheme.HighlightStyle)
 	m.output.AddEmptyLine()
 	m.updateViewportContent()
 	m.viewport.GotoBottom()

--- a/internal/cli/repl/widgets/model_selection.go
+++ b/internal/cli/repl/widgets/model_selection.go
@@ -101,7 +101,7 @@ func (m *Model) handleKeyMsg(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 			m.SelectedModel = m.ModelList[m.ModelCursor].ID
 			modelMeta, ok := m.registry.GetModel(m.SelectedProvider, m.SelectedModel)
 			if ok && modelMeta.SupportsThinkingEffort() {
-				m.ThinkingOptions = append([]string{"off"}, modelMeta.ThinkingEfforts...)
+				m.ThinkingOptions = modelMeta.ThinkingEfforts
 				m.ThinkingCursor = m.resolveThinkingCursor(m.ThinkingOptions)
 				m.Step = StepThinking
 			} else if supportsBaseURL(m.SelectedProvider) {
@@ -181,20 +181,18 @@ func (m *Model) resolveThinkingCursor(options []string) int {
 		currentEffort = m.resolvedCfg.ThinkingEffort
 	}
 	if currentEffort == "" {
-		// Try "medium" default, else "off"
 		if idx := slices.Index(options, "medium"); idx >= 0 {
 			return idx
 		}
-		return 0 // "off"
+		return 0
 	}
 	if idx := slices.Index(options, currentEffort); idx >= 0 {
 		return idx
 	}
-	// Saved value not compatible — prefer medium
 	if idx := slices.Index(options, "medium"); idx >= 0 {
 		return idx
 	}
-	return 0 // "off"
+	return 0
 }
 
 func (m *Model) handlePasteMsg(msg tea.PasteMsg) (*Model, tea.Cmd) {
@@ -228,11 +226,7 @@ func (m *Model) complete() (*Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Resolve the stored effort value ("off" → "")
 	storedEffort := m.SelectedThinking
-	if storedEffort == "off" {
-		storedEffort = ""
-	}
 
 	// If model doesn't support configurable effort, clear any stale value
 	modelMeta, ok := m.registry.GetModel(m.SelectedProvider, m.SelectedModel)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ const (
 	ProviderGoogleAI   = "googleai"
 	ProviderMoonshotAI = "moonshotai"
 	ProviderDeepSeek   = "deepseek"
+	ProviderZAI        = "zai"
 )
 
 type GlobalConfig struct {

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -50,7 +50,8 @@ func NewClient(cfg *config.ResolvedConfig) (LLMClient, error) {
 			BaseURL:        cfg.BaseURL,
 		})
 	case config.ProviderDeepSeek,
-		config.ProviderMoonshotAI:
+		config.ProviderMoonshotAI,
+		config.ProviderZAI:
 		return NewOpenAICompatibleClient(&ClientConfig{
 			Provider:       Provider(cfg.Provider),
 			APIKey:         cfg.APIKey,

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -162,6 +162,35 @@ func TestProviderConstants(t *testing.T) {
 	}
 }
 
+func TestNewClient_ZAI(t *testing.T) {
+	cfg := &config.ResolvedConfig{
+		Provider: "zai",
+		Model:    "glm-4-plus",
+		APIKey:   "test-api-key",
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+
+	oaiClient, ok := client.(*OpenAICompatibleClient)
+	if !ok {
+		t.Fatalf("expected *OpenAICompatibleClient, got %T", client)
+	}
+
+	if oaiClient.provider != Provider(config.ProviderZAI) {
+		t.Errorf("expected provider zai, got %s", oaiClient.provider)
+	}
+	if oaiClient.model != "glm-4-plus" {
+		t.Errorf("expected model glm-4-plus, got %s", oaiClient.model)
+	}
+}
+
 func TestNewClient_DeepSeek(t *testing.T) {
 	cfg := &config.ResolvedConfig{
 		Provider: "deepseek",

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -91,6 +91,8 @@ func openAICompatibleBaseURL(provider Provider) (string, error) {
 		return "https://api.deepseek.com/", nil
 	case Provider(config.ProviderMoonshotAI):
 		return "https://api.moonshot.ai/v1/", nil
+	case Provider(config.ProviderZAI):
+		return "https://api.z.ai/api/paas/v4/", nil
 	default:
 		return "", fmt.Errorf("unsupported OpenAI-compatible provider: %s", provider)
 	}
@@ -292,6 +294,13 @@ func (c *OpenAICompatibleClient) StreamChat(
 			}
 			if len(oaiTools) > 0 {
 				params.Tools = oaiTools
+			}
+			if c.provider == Provider(config.ProviderZAI) && c.thinkingEffort != "" {
+				params.SetExtraFields(map[string]any{
+					"thinking": map[string]any{
+						"type": c.thinkingEffort,
+					},
+				})
 			}
 			message, reasoningContent, streamedContent, hasChoice, usage, err := c.collectTurn(ctx, params, eventCh)
 			if err != nil {

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -234,6 +234,23 @@ func TestOpenAICompatibleClient_StreamChat_InjectsReasoningContentAcrossToolTurn
 	}
 }
 
+func TestNewOpenAICompatibleClient_ZAI(t *testing.T) {
+	client, err := NewOpenAICompatibleClient(&ClientConfig{
+		Provider: Provider(config.ProviderZAI),
+		APIKey:   "test-key",
+		Model:    "glm-4-plus",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected client")
+	}
+	if client.model != "glm-4-plus" {
+		t.Fatalf("expected model glm-4-plus, got %s", client.model)
+	}
+}
+
 func TestOpenAICompatibleClient_IgnoresThinkingEffort(t *testing.T) {
 	// DeepSeek/Moonshot compatible clients store but ignore thinkingEffort
 	client, err := NewOpenAICompatibleClient(&ClientConfig{
@@ -247,6 +264,79 @@ func TestOpenAICompatibleClient_IgnoresThinkingEffort(t *testing.T) {
 	}
 	if client.thinkingEffort != "high" {
 		t.Errorf("expected thinkingEffort 'high' stored, got %q", client.thinkingEffort)
+	}
+}
+
+func TestOpenAICompatibleClient_ZAI_ThinkingEnabled(t *testing.T) {
+	client := &OpenAICompatibleClient{
+		provider:       Provider(config.ProviderZAI),
+		model:          "glm-5.1",
+		thinkingEffort: "enabled",
+	}
+
+	var capturedParams openai.ChatCompletionNewParams
+	client.streamImpl = func(ctx context.Context, params openai.ChatCompletionNewParams, opts ...option.RequestOption) chatStream {
+		capturedParams = params
+		return &fakeChatStream{
+			chunks: []openai.ChatCompletionChunk{makeContentChunk("hello")},
+		}
+	}
+
+	eventCh, err := client.StreamChat(context.Background(), []Message{
+		{Role: RoleUser, Content: "test"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for range eventCh {
+	}
+
+	extra := capturedParams.ExtraFields()
+	if extra == nil {
+		t.Fatal("expected extra fields with thinking config")
+	}
+	thinking, ok := extra["thinking"]
+	if !ok {
+		t.Fatal("expected 'thinking' in extra fields")
+	}
+	thinkingMap, ok := thinking.(map[string]any)
+	if !ok {
+		t.Fatalf("expected thinking to be map[string]any, got %T", thinking)
+	}
+	if thinkingMap["type"] != "enabled" {
+		t.Fatalf("expected thinking type 'enabled', got %v", thinkingMap["type"])
+	}
+}
+
+func TestOpenAICompatibleClient_ZAI_ThinkingDisabled(t *testing.T) {
+	client := &OpenAICompatibleClient{
+		provider:       Provider(config.ProviderZAI),
+		model:          "glm-5.1",
+		thinkingEffort: "",
+	}
+
+	var capturedParams openai.ChatCompletionNewParams
+	client.streamImpl = func(ctx context.Context, params openai.ChatCompletionNewParams, opts ...option.RequestOption) chatStream {
+		capturedParams = params
+		return &fakeChatStream{
+			chunks: []openai.ChatCompletionChunk{makeContentChunk("hello")},
+		}
+	}
+
+	eventCh, err := client.StreamChat(context.Background(), []Message{
+		{Role: RoleUser, Content: "test"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for range eventCh {
+	}
+
+	extra := capturedParams.ExtraFields()
+	if extra != nil {
+		if _, ok := extra["thinking"]; ok {
+			t.Fatal("expected no thinking config when thinkingEffort is empty")
+		}
 	}
 }
 

--- a/providers/registry.yaml
+++ b/providers/registry.yaml
@@ -57,6 +57,18 @@ providers:
         name: Kimi K2 Thinking Turbo
         context_window: 256000
 
+  - id: zai
+    name: Z.ai (GLM)
+    models:
+      - id: glm-5.1
+        name: GLM-5.1
+        context_window: 200000
+        thinking_efforts: ["enabled", "disabled"]
+      - id: glm-5
+        name: GLM-5
+        context_window: 200000
+        thinking_efforts: ["enabled", "disabled"]
+
   - id: deepseek
     name: DeepSeek
     models:


### PR DESCRIPTION
## What does this PR do?

- Add ProviderZAI constant and default base URL (https://api.z.ai/api/paas/v4/)
- Route Z.ai through existing OpenAICompatibleClient
- Add GLM thinking support via thinking extra field in chat params
- Register GLM-5 and GLM-5.1 models with enabled/disabled thinking efforts
- Remove "off" as a pseudo thinking effort — efforts are now model-defined only
- Add tests for Z.ai client creation, base URL, and thinking param injection

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New tool
- [x] New provider or model
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] `go test ./...` passes
- [x] `go mod tidy` has been run
- [x] New behavior is covered by tests where it makes sense
- [x] For new providers: entry added to `providers/registry.yaml` with correct `context_window`