### PR TITLE
feat(history): implement input history navigation

### DIFF
--- a/.ai-interactions/tasks/issue-4/output-1_input-history-nav-plan.md
+++ b/.ai-interactions/tasks/issue-4/output-1_input-history-nav-plan.md
@@ -1,0 +1,165 @@
+# Input History Navigation — Implementation Plan
+
+## Issue Summary
+GitHub issue #4: Navigate previously submitted inputs using the Up/Down arrow keys,
+similar to shell history (Up = older, Down = newer / restore draft).
+
+---
+
+## Current Behaviour
+
+In `handlers.go → handleKeyMsg`:
+
+- `keyUp` / `keyShiftUp` — when the textarea cursor is on the **first line**, scroll
+  the viewport up by one line.
+- `keyDown` / `keyShiftDown` — when the cursor is on the **last line**, scroll the
+  viewport down by one line.
+
+There is no history tracking at all today.
+
+---
+
+## Desired Behaviour
+
+| Key     | Cursor position      | Action                                          |
+|---------|----------------------|-------------------------------------------------|
+| Up      | First line of input  | Replace textarea content with the previous (older) history entry |
+| Down    | Last line of input, in history mode | Replace textarea content with the next (newer) entry, or restore the draft |
+| Up/Down | Any other cursor position | Existing textarea cursor-movement (no change) |
+| Up/Down | Suggestion widget visible | Already handled by suggestion logic — no change needed |
+
+A **draft** is the in-progress text the user was typing before they started pressing
+Up to navigate history. Pressing Down past the most-recent entry restores the draft.
+
+---
+
+## Implementation
+
+### 1. New file: `internal/cli/repl/input_history.go`
+
+Encapsulate history state in a small, testable struct.
+
+```go
+type inputHistory struct {
+    entries  []string // oldest → newest
+    idx      int      // -1 = draft mode; 0..len-1 = viewing a history entry
+    draft    string   // text saved when entering history mode
+    filePath string   // ~/.keen/input-history
+}
+
+const maxHistorySize = 1000
+```
+
+Methods:
+
+| Method | Description |
+|---|---|
+| `push(entry string)` | Append entry (skip blanks, exact duplicates of last, and slash commands). Trim to `maxHistorySize`. Reset `idx = -1`, clear `draft`. Then call `appendToFile`. |
+| `navigateUp(current string) (value string, ok bool)` | Save `current` as `draft` on first call (when `idx == -1`). Decrement `idx` toward 0. Return the entry at the new index. Returns `ok=false` if already at oldest entry. |
+| `navigateDown() (value string, ok bool)` | Increment `idx`. If we pass the newest entry (`idx == -1`), return `draft` and reset to draft mode. Returns `ok=false` if already in draft mode and nothing to restore. |
+| `reset()` | `idx = -1`, `draft = ""`. Called on `/clear` and session load. |
+| `loadFromFile(path string) error` | Reads `~/.keen/input-history`, one entry per line (with `\n` literals unescaped). Populates `entries`. Deduplicates consecutive identical lines. If file is missing, returns silently. Stores `path` in `filePath`. |
+| `appendToFile(entry string) error` | Appends a single escaped entry (newlines → `\n` literals) to `filePath`. Non-fatal: failure is silently ignored so the session is never blocked. |
+
+### 2. Add field to `replModel` in `repl.go`
+
+```go
+type replModel struct {
+    // ...existing fields...
+    history inputHistory
+}
+```
+
+In `initialModel()`, call `history.loadFromFile(path)` where `path` is
+`filepath.Join(os.UserHomeDir(), ".keen", "input-history")`. Use `os.MkdirAll` to
+create `~/.keen/` if it doesn't exist. A load failure is non-fatal — start with empty
+history.
+
+### 3. Modify `handleEnterKey` in `repl.go`
+
+After validating `input != ""` and **before** `m.textarea.Reset()`, push the input
+to history and reset the navigation index:
+
+```go
+m.history.push(input)
+```
+
+Only push messages and skip slash commands.
+
+### 4. Modify `handleKeyMsg` in `handlers.go`
+
+Replace the existing `keyUp` and `keyDown` cases:
+
+```go
+case keyUp, keyShiftUp:
+    if m.isAtTopOfInput() {
+        if val, ok := m.history.navigateUp(m.textarea.Value()); ok {
+            m.textarea.SetValue(val)
+            m.textarea.MoveToBeginning() // keep cursor at top
+            m.adjustTextareaHeight()
+            return *m, nil
+        }
+        // at oldest entry or empty history — fall through to viewport scroll
+        m.viewport.ScrollUp(1)
+        m.userScrolled = !m.viewport.AtBottom()
+        return *m, nil
+    }
+
+case keyDown, keyShiftDown:
+    if m.isAtBottomOfInput() {
+        if val, ok := m.history.navigateDown(); ok {
+            m.textarea.SetValue(val)
+            m.textarea.MoveToEnd()
+            m.adjustTextareaHeight()
+            return *m, nil
+        }
+        // in draft mode with nothing newer — fall through to viewport scroll
+        m.viewport.ScrollDown(1)
+        m.userScrolled = !m.viewport.AtBottom()
+        return *m, nil
+    }
+```
+
+No changes are needed to the suggestion-widget intercept path — it already fires
+before the Up/Down cases and consumes those keys.
+
+### 5. New test file: `internal/cli/repl/input_history_test.go`
+
+Cover:
+
+- `push`: blank entry is ignored; duplicate of last entry is ignored; max size trim; `appendToFile` is called.
+- `loadFromFile`: missing file is a no-op; consecutive duplicates are deduplicated; multi-line entries are unescaped correctly.
+- `appendToFile`: multi-line entries are escaped to `\n` literals; write failure does not panic.
+- `navigateUp`: saves draft on first call; steps through entries; returns `ok=false`
+  at oldest.
+- `navigateDown`: steps back toward draft; restores draft; returns `ok=false` when
+  already in draft mode.
+- Full round-trip: push several entries → Up × N → Down × N → confirm draft restored.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/cli/repl/input_history.go` | **New** — `inputHistory` struct + methods including `loadFromFile` and `appendToFile` |
+| `internal/cli/repl/input_history_test.go` | **New** — unit tests |
+| `internal/cli/repl/repl.go` | Add `history inputHistory` field; call `loadFromFile` + `os.MkdirAll` in `initialModel()` |
+| `internal/cli/repl/handlers.go` | Update `keyUp` / `keyDown` cases; push in `handleEnterKey`; reset in `handleClear` |
+| `internal/cli/repl/repl.go` | Also call `m.history.reset()` inside `replayLoadedSession()` |
+
+---
+
+## Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| Empty textarea on submission | Already guarded (`if input == ""`); not pushed |
+| Consecutive identical submissions | Skipped in `push` (no duplicate of last entry) |
+| Multi-line input (Ctrl+Enter) | Stored and restored as-is; textarea supports multi-line |
+| Suggestion widget visible | Keys consumed by suggestion logic before reaching history code |
+| Stream active | User can still navigate history (read-only); cannot submit until stream ends |
+| Session load / resume | `reset()` clears navigation state (`idx`, `draft`) and is called in both `handleClear()` and `replayLoadedSession()`; history entries persist across sessions via `~/.keen/input-history` |
+| History overflow | Capped at `maxHistorySize = 1000`; oldest entries dropped on load if file exceeds cap (rewritten once at startup) |
+| Concurrent instances | Append-only writes are safe; a second instance won't see new entries until restarted (matches shell behaviour) |
+| Write failure | `appendToFile` failure is silently ignored — history is a UX nicety, never fatal |

--- a/.ai-interactions/tasks/issue-4/prompt-1_input-history-nav.md
+++ b/.ai-interactions/tasks/issue-4/prompt-1_input-history-nav.md
@@ -1,0 +1,9 @@
+## Input Navigation through Arrow Keys
+
+1. Ok we need to work on issue #4 here: https://github.com/mochow13/keen-code/issues/4. Based on the requirements, create a plan to implement the input history navigation. Save the plan in @.ai-interactions/tasks/issue-4/output-1_input-history-nav-plan.md
+2. In @.ai-interactions/tasks/issue-4/output-1_input-history-nav-plan.md, what will happen if a new session is created or an old one loaded back?
+3. Implement the plan.
+4. Can we move input_history and its test files to a subpackage named "history"?
+5. Can we put the cursor at the end of each input when navigating history?
+6. How are we ensuring the history file doesn't contain more than 1000 inputs from the user?
+7. Let's rewrite history upon successful exit. There we can ensure we only retain the last 1000 inputs from the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,4 @@ Guard checks paths before filesystem operations:
 - Commit messages should be concise and focus on the key changes with bullet points
 - Commit messages should follow the `feat(category): description` format
 - Always check both tracked and untracked files for creating the commit message
-- Never add additional authors to the commit message
+- Never add co-authors or made-with AI tags to the commit message

--- a/internal/cli/repl/handlers.go
+++ b/internal/cli/repl/handlers.go
@@ -107,9 +107,11 @@ func (m *replModel) handleLLMError(err error) (replModel, tea.Cmd) {
 		Content:    partialResponse,
 		TurnMemory: turnMemory,
 	}
-	m.appState.AppendMessage(assistantMessage)
-	if persistErr := m.sessions.appendAssistantTurn(segments, assistantMessage, false, errMsg); persistErr != nil {
-		m.handleSessionPersistenceError(persistErr)
+	if partialResponse != "" || (turnMemory != nil && !turnMemory.IsEmpty()) {
+		m.appState.AppendMessage(assistantMessage)
+		if persistErr := m.sessions.appendAssistantTurn(segments, assistantMessage, false, errMsg); persistErr != nil {
+			m.handleSessionPersistenceError(persistErr)
+		}
 	}
 	for _, line := range pendingLines {
 		m.output.AddLine(line)

--- a/internal/cli/repl/handlers.go
+++ b/internal/cli/repl/handlers.go
@@ -364,6 +364,7 @@ func (m *replModel) handleKeyMsg(msg tea.Msg) (replModel, tea.Cmd) {
 			return *m, nil
 		}
 		m.quitting = true
+		_ = m.history.Flush()
 		return *m, tea.Quit
 	case keyEsc:
 		if m.streamHandler != nil && m.streamHandler.IsActive() {
@@ -372,12 +373,24 @@ func (m *replModel) handleKeyMsg(msg tea.Msg) (replModel, tea.Cmd) {
 		return *m, nil
 	case keyUp, keyShiftUp:
 		if m.isAtTopOfInput() {
+			if val, ok := m.history.NavigateUp(m.textarea.Value()); ok {
+				m.textarea.SetValue(val)
+				m.textarea.MoveToEnd()
+				m.adjustTextareaHeight()
+				return *m, nil
+			}
 			m.viewport.ScrollUp(1)
 			m.userScrolled = !m.viewport.AtBottom()
 			return *m, nil
 		}
 	case keyDown, keyShiftDown:
 		if m.isAtBottomOfInput() {
+			if val, ok := m.history.NavigateDown(); ok {
+				m.textarea.SetValue(val)
+				m.textarea.MoveToEnd()
+				m.adjustTextareaHeight()
+				return *m, nil
+			}
 			m.viewport.ScrollDown(1)
 			m.userScrolled = !m.viewport.AtBottom()
 			return *m, nil

--- a/internal/cli/repl/history/history.go
+++ b/internal/cli/repl/history/history.go
@@ -1,0 +1,134 @@
+package history
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+const MaxHistorySize = 1000
+
+type InputHistory struct {
+	entries  []string
+	idx      int
+	draft    string
+	filePath string
+}
+
+func (h *InputHistory) Push(entry string) {
+	if strings.TrimSpace(entry) == "" {
+		return
+	}
+	if strings.HasPrefix(entry, "/") {
+		return
+	}
+	if len(h.entries) > 0 && h.entries[len(h.entries)-1] == entry {
+		return
+	}
+	h.entries = append(h.entries, entry)
+	if len(h.entries) > MaxHistorySize {
+		h.entries = h.entries[len(h.entries)-MaxHistorySize:]
+	}
+	h.idx = -1
+	h.draft = ""
+	_ = h.AppendToFile(entry)
+}
+
+func (h *InputHistory) NavigateUp(current string) (string, bool) {
+	if len(h.entries) == 0 {
+		return "", false
+	}
+	if h.idx == -1 {
+		h.draft = current
+		h.idx = len(h.entries) - 1
+		return h.entries[h.idx], true
+	}
+	if h.idx == 0 {
+		return "", false
+	}
+	h.idx--
+	return h.entries[h.idx], true
+}
+
+func (h *InputHistory) NavigateDown() (string, bool) {
+	if h.idx == -1 {
+		return "", false
+	}
+	if h.idx == len(h.entries)-1 {
+		h.idx = -1
+		return h.draft, true
+	}
+	h.idx++
+	return h.entries[h.idx], true
+}
+
+func (h *InputHistory) Reset() {
+	h.idx = -1
+	h.draft = ""
+}
+
+func (h *InputHistory) LoadFromFile(path string) error {
+	h.filePath = path
+	h.idx = -1
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var entries []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		entry := strings.ReplaceAll(line, `\n`, "\n")
+		if len(entries) > 0 && entries[len(entries)-1] == entry {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if len(entries) > MaxHistorySize {
+		entries = entries[len(entries)-MaxHistorySize:]
+	}
+	h.entries = entries
+	return nil
+}
+
+func (h *InputHistory) Flush() error {
+	if h.filePath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(h.filePath, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	for _, entry := range h.entries {
+		escaped := strings.ReplaceAll(entry, "\n", `\n`)
+		if _, err := w.WriteString(escaped + "\n"); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func (h *InputHistory) AppendToFile(entry string) error {
+	if h.filePath == "" {
+		return nil
+	}
+	escaped := strings.ReplaceAll(entry, "\n", `\n`)
+	f, err := os.OpenFile(h.filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(escaped + "\n")
+	return err
+}

--- a/internal/cli/repl/history/history_test.go
+++ b/internal/cli/repl/history/history_test.go
@@ -1,0 +1,327 @@
+package history_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/user/keen-code/internal/cli/repl/history"
+)
+
+func TestInputHistory_Push_BlankIgnored(t *testing.T) {
+	var h history.InputHistory
+	h.Push("")
+	h.Push("   ")
+	// no panic and NavigateUp returns false
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected no entries for blank inputs")
+	}
+}
+
+func TestInputHistory_Push_SlashCommandIgnored(t *testing.T) {
+	var h history.InputHistory
+	h.Push("/clear")
+	h.Push("/help")
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected slash commands to be ignored")
+	}
+}
+
+func TestInputHistory_Push_DuplicateLastIgnored(t *testing.T) {
+	var h history.InputHistory
+	h.Push("hello")
+	h.Push("hello")
+	// Only one entry: navigating up twice from start should fail on second
+	h.NavigateUp("")
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected only 1 entry after duplicate push")
+	}
+}
+
+func TestInputHistory_Push_MaxSizeTrimmed(t *testing.T) {
+	var h history.InputHistory
+	for i := range history.MaxHistorySize + 10 {
+		h.Push(strings.Repeat("x", i+1))
+	}
+	// Navigate up MaxHistorySize times should succeed, one more should fail
+	for i := 0; i < history.MaxHistorySize; i++ {
+		_, ok := h.NavigateUp("")
+		if !ok {
+			t.Fatalf("expected ok=true at step %d", i)
+		}
+	}
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected ok=false after exhausting max history")
+	}
+}
+
+func TestInputHistory_Push_ResetsNavigation(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+	h.Push("second")
+	h.NavigateUp("draft")
+	h.Push("third")
+	// After push, navigateDown should return false (already in draft mode)
+	_, ok := h.NavigateDown()
+	if ok {
+		t.Fatal("expected idx to be reset to -1 after push")
+	}
+}
+
+func TestInputHistory_NavigateUp_SavesDraft(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+	h.Push("second")
+
+	val, ok := h.NavigateUp("my draft")
+	if !ok {
+		t.Fatal("expected ok=true on first NavigateUp")
+	}
+	if val != "second" {
+		t.Fatalf("expected newest entry 'second', got %q", val)
+	}
+}
+
+func TestInputHistory_NavigateUp_StopsAtOldest(t *testing.T) {
+	var h history.InputHistory
+	h.Push("only")
+
+	h.NavigateUp("")
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected ok=false when already at oldest entry")
+	}
+}
+
+func TestInputHistory_NavigateUp_EmptyHistory(t *testing.T) {
+	var h history.InputHistory
+	_, ok := h.NavigateUp("draft")
+	if ok {
+		t.Fatal("expected ok=false for empty history")
+	}
+}
+
+func TestInputHistory_NavigateDown_RestoresDraft(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+
+	h.NavigateUp("my draft")
+	val, ok := h.NavigateDown()
+	if !ok {
+		t.Fatal("expected ok=true when navigating back to draft")
+	}
+	if val != "my draft" {
+		t.Fatalf("expected draft restored, got %q", val)
+	}
+	// Now in draft mode — another NavigateDown should return false
+	_, ok = h.NavigateDown()
+	if ok {
+		t.Fatal("expected ok=false after restoring draft")
+	}
+}
+
+func TestInputHistory_NavigateDown_AlreadyInDraftMode(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+
+	_, ok := h.NavigateDown()
+	if ok {
+		t.Fatal("expected ok=false when already in draft mode")
+	}
+}
+
+func TestInputHistory_NavigateDown_StepsForward(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+	h.Push("second")
+	h.Push("third")
+
+	h.NavigateUp("")
+	h.NavigateUp("")
+	// now at "second"
+	val, ok := h.NavigateDown()
+	if !ok {
+		t.Fatal("expected ok=true when stepping forward")
+	}
+	if val != "third" {
+		t.Fatalf("expected 'third', got %q", val)
+	}
+}
+
+func TestInputHistory_Reset(t *testing.T) {
+	var h history.InputHistory
+	h.Push("first")
+	h.NavigateUp("draft")
+	h.Reset()
+	// After reset, NavigateDown should return false (draft mode)
+	_, ok := h.NavigateDown()
+	if ok {
+		t.Fatal("expected idx=-1 after reset")
+	}
+}
+
+func TestInputHistory_LoadFromFile_MissingFileIsNoop(t *testing.T) {
+	var h history.InputHistory
+	err := h.LoadFromFile(filepath.Join(t.TempDir(), "nonexistent"))
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected empty entries")
+	}
+}
+
+func TestInputHistory_LoadFromFile_DeduplicatesConsecutive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input-history")
+	content := "hello\nhello\nworld\nworld\nhello\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var h history.InputHistory
+	if err := h.LoadFromFile(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// hello, world, hello (consecutive dups removed) — navigate up 3 times
+	for i := 0; i < 3; i++ {
+		_, ok := h.NavigateUp("")
+		if !ok {
+			t.Fatalf("expected ok=true at step %d", i)
+		}
+	}
+	_, ok := h.NavigateUp("")
+	if ok {
+		t.Fatal("expected exactly 3 entries after dedup")
+	}
+}
+
+func TestInputHistory_LoadFromFile_UnescapesNewlines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input-history")
+	if err := os.WriteFile(path, []byte(`line1\nline2`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var h history.InputHistory
+	if err := h.LoadFromFile(path); err != nil {
+		t.Fatal(err)
+	}
+
+	val, ok := h.NavigateUp("")
+	if !ok {
+		t.Fatal("expected 1 entry")
+	}
+	if val != "line1\nline2" {
+		t.Fatalf("expected unescaped newline, got %q", val)
+	}
+}
+
+func TestInputHistory_AppendToFile_EscapesNewlines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input-history")
+
+	var h history.InputHistory
+	if err := h.LoadFromFile(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.AppendToFile("line1\nline2"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `line1\nline2`) {
+		t.Fatalf("expected escaped newline in file, got %q", string(data))
+	}
+}
+
+func TestInputHistory_AppendToFile_NoFilePath(t *testing.T) {
+	var h history.InputHistory
+	err := h.AppendToFile("hello")
+	if err != nil {
+		t.Fatalf("expected no error for empty filePath, got %v", err)
+	}
+}
+
+func TestInputHistory_Flush_RewritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input-history")
+
+	var h history.InputHistory
+	_ = h.LoadFromFile(path)
+	h.Push("first")
+	h.Push("second")
+	h.Push("third")
+
+	if err := h.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines in flushed file, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "first" || lines[1] != "second" || lines[2] != "third" {
+		t.Fatalf("unexpected lines: %v", lines)
+	}
+}
+
+func TestInputHistory_Flush_NoFilePath(t *testing.T) {
+	var h history.InputHistory
+	h.Push("hello")
+	if err := h.Flush(); err != nil {
+		t.Fatalf("expected no error for empty filePath, got %v", err)
+	}
+}
+
+func TestInputHistory_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "input-history")
+
+	var h history.InputHistory
+	_ = h.LoadFromFile(path)
+	h.Push("first")
+	h.Push("second")
+	h.Push("third")
+
+	v1, ok := h.NavigateUp("draft")
+	if !ok || v1 != "third" {
+		t.Fatalf("expected 'third', got %q ok=%v", v1, ok)
+	}
+	v2, ok := h.NavigateUp(v1)
+	if !ok || v2 != "second" {
+		t.Fatalf("expected 'second', got %q ok=%v", v2, ok)
+	}
+	v3, ok := h.NavigateUp(v2)
+	if !ok || v3 != "first" {
+		t.Fatalf("expected 'first', got %q ok=%v", v3, ok)
+	}
+
+	h.NavigateDown()
+	h.NavigateDown()
+	restored, ok := h.NavigateDown()
+	if !ok {
+		t.Fatal("expected ok=true when restoring draft")
+	}
+	if restored != "draft" {
+		t.Fatalf("expected draft 'draft', got %q", restored)
+	}
+	_, ok = h.NavigateDown()
+	if ok {
+		t.Fatal("expected ok=false after full round-trip")
+	}
+}

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -397,6 +397,7 @@ func (m *replModel) handleEnterKey() (replModel, tea.Cmd) {
 
 	if input == exitCommand {
 		m.quitting = true
+		_ = m.history.Flush()
 		return *m, tea.Quit
 	}
 

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -16,6 +16,7 @@ import (
 	"charm.land/lipgloss/v2"
 	replappstate "github.com/user/keen-code/internal/cli/repl/appstate"
 	replfilesearch "github.com/user/keen-code/internal/cli/repl/filesearch"
+	replhistory "github.com/user/keen-code/internal/cli/repl/history"
 	replmarkdown "github.com/user/keen-code/internal/cli/repl/markdown"
 	reploutput "github.com/user/keen-code/internal/cli/repl/output"
 	replpermissions "github.com/user/keen-code/internal/cli/repl/permissions"
@@ -163,6 +164,7 @@ type replModel struct {
 	isCompacting        bool
 	compactionCancel    context.CancelFunc
 	contextStatus       contextStatus
+	history             replhistory.InputHistory
 }
 
 func abbreviateHome(path string) string {
@@ -201,7 +203,7 @@ func initialModel(ctx *replContext, llmClient llm.LLMClient, needsSetup bool) re
 	styles.Blurred.CursorLine = lipgloss.NewStyle()
 	ta.SetStyles(styles)
 
-	ta.KeyMap.InsertNewline.SetKeys("ctrl+enter")
+	ta.KeyMap.InsertNewline.SetKeys("shift+enter")
 	ta.KeyMap.InsertNewline.SetEnabled(true)
 
 	s := spinner.New()
@@ -251,6 +253,15 @@ func initialModel(ctx *replContext, llmClient llm.LLMClient, needsSetup bool) re
 		fileSearcher:        fileSearcher,
 	}
 	model.streamHandler.workingDir = ctx.workingDir
+
+	historyDir, err := os.UserHomeDir()
+	if err == nil {
+		historyDir = filepath.Join(historyDir, ".keen")
+		if mkdirErr := os.MkdirAll(historyDir, 0755); mkdirErr == nil {
+			_ = model.history.LoadFromFile(filepath.Join(historyDir, "input-history"))
+		}
+	}
+
 	model.refreshContextStatus()
 
 	if needsSetup {
@@ -304,7 +315,7 @@ func buildInitialScreen(ctx *replContext) []string {
 	tips := []string{
 		"Use /help  for available commands",
 		"Use /model to change provider or model",
-		"Press Enter to send, Ctrl+Enter for new line",
+		"Press Enter to send, Shift+Enter for new line",
 		"Shift+click to select and copy text",
 	}
 	tipsBox := repltheme.BoxStyle.Render(repltheme.TipStyle.Render(strings.Join(tips, "\n")))
@@ -382,6 +393,7 @@ func (m *replModel) handleEnterKey() (replModel, tea.Cmd) {
 	}
 
 	m.output.AddUserInput(input, repltheme.PromptStyle)
+	m.history.Push(input)
 
 	if input == exitCommand {
 		m.quitting = true
@@ -971,6 +983,7 @@ func (m *replModel) handleClear() replModel {
 	m.appState.ClearMessages()
 	m.appState.ClearContextMetrics()
 	m.sessions.resetSession()
+	m.history.Reset()
 
 	newOutput := reploutput.NewOutputBuilder(m.width, m.ctx.workingDir)
 	initialLines := buildInitialScreen(m.ctx)
@@ -1018,6 +1031,7 @@ func (m *replModel) replayLoadedSession(loaded *session.LoadedSession) {
 
 	m.output = replay.output
 	m.appState.ReplaceMessages(session.BuildConversation(loaded.Events))
+	m.history.Reset()
 	m.sessionPicker = nil
 	m.refreshContextStatus()
 	m.updateViewportContent()

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -84,9 +84,13 @@ func toAnthropicMessages(messages []Message) ([]anthropic.TextBlockParam, []anth
 		case RoleSystem:
 			systemBlocks = append(systemBlocks, anthropic.TextBlockParam{Text: content})
 		case RoleUser:
-			msgParams = append(msgParams, anthropic.NewUserMessage(anthropic.NewTextBlock(content)))
+			if content != "" {
+				msgParams = append(msgParams, anthropic.NewUserMessage(anthropic.NewTextBlock(content)))
+			}
 		case RoleAssistant:
-			msgParams = append(msgParams, anthropic.NewAssistantMessage(anthropic.NewTextBlock(content)))
+			if content != "" {
+				msgParams = append(msgParams, anthropic.NewAssistantMessage(anthropic.NewTextBlock(content)))
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

- add history subpackage with InputHistory struct
- persist history to ~/.keen/input-history with append on push
- flush (rewrite) file to last 1000 entries on clean exit
- navigate with Up/Down keys, cursor placed at end of entry
- reset navigation state on clear and session load
- add comprehensive tests for all history operations

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New tool
- [ ] New provider or model
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] `go test ./...` passes
- [x] `go mod tidy` has been run
- [x] New behavior is covered by tests where it makes sense
- [ ] For new providers: entry added to `providers/registry.yaml` with correct `context_window`