### PR TITLE
feat(repl): support text selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,14 @@ require (
 	charm.land/bubbletea/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.0
 	github.com/anthropics/anthropic-sdk-go v1.37.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-udiff v0.4.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1
 	github.com/charmbracelet/glamour v0.10.0
+	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8
+	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/clipperhouse/displaywidth v0.11.0
+	github.com/clipperhouse/uax29/v2 v2.7.0
 	github.com/firebase/genkit/go v1.4.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/openai/openai-go v1.8.2
@@ -23,22 +28,17 @@ require (
 	cloud.google.com/go/auth v0.16.2 // indirect
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
-	github.com/clipperhouse/displaywidth v0.11.0 // indirect
-	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -71,6 +71,8 @@ type replModel struct {
 	contextStatus       contextStatus
 	showThinking        bool
 	history             replhistory.InputHistory
+	selection           viewportSelection
+	inputSelection      viewportSelection
 }
 
 func initialModel(ctx *replContext, llmClient llm.LLMClient, needsSetup bool) replModel {
@@ -274,7 +276,9 @@ func (m *replModel) updateViewportContent() {
 		content.WriteString(replwidgets.FormatSessionPickerCard(m.sessionPicker, m.viewport.Width(), m.viewport.Height()))
 	}
 
-	m.viewport.SetContent(content.String())
+	viewportContent := content.String()
+	m.viewport.SetContent(viewportContent)
+	m.selection.setContent(viewportContent)
 }
 
 func (m replModel) waitForAsyncEvent() tea.Cmd {
@@ -353,7 +357,41 @@ func (m replModel) updateNormalMode(msg tea.Msg) (replModel, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyPressMsg:
+		if m.inputSelection.hasSelection() {
+			if isSelectionCopyKey(msg) {
+				return m, copySelectedTextCmd(m.inputSelection.selectedText())
+			}
+			if msg.String() == keyEsc {
+				m.inputSelection.clear()
+				return m, nil
+			}
+			m.inputSelection.clear()
+		}
+		if m.selection.hasSelection() {
+			if isSelectionCopyKey(msg) {
+				return m, copySelectedTextCmd(m.selection.selectedText())
+			}
+			if msg.String() == keyEsc {
+				m.selection.clear()
+				return m, nil
+			}
+		}
 		return m.handleKeyMsg(msg)
+
+	case tea.MouseClickMsg:
+		if handled, cmd := m.handleMouseDown(msg); handled {
+			return m, cmd
+		}
+
+	case tea.MouseMotionMsg:
+		if handled := m.handleMouseDrag(msg); handled {
+			return m, nil
+		}
+
+	case tea.MouseReleaseMsg:
+		if handled, cmd := m.handleMouseUp(); handled {
+			return m, cmd
+		}
 
 	case tea.MouseWheelMsg:
 		switch msg.Button {
@@ -421,7 +459,8 @@ func (m replModel) View() tea.View {
 	} else {
 		var view strings.Builder
 
-		view.WriteString(m.viewport.View())
+		viewportView := m.selection.render(m.viewport.View(), m.viewport.Width(), m.viewport.Height(), m.viewport.YOffset())
+		view.WriteString(viewportView)
 		view.WriteString("\n")
 
 		if m.showSpinner {
@@ -431,7 +470,8 @@ func (m replModel) View() tea.View {
 			view.WriteString("\n")
 		}
 
-		view.WriteString(renderInputArea(m.textarea.View(), m.width))
+		textareaView := m.inputSelection.renderWithColumnOffset(m.textarea.View(), m.textarea.Width()+inputPromptWidth, m.textarea.Height(), m.textarea.ScrollYOffset(), inputPromptWidth)
+		view.WriteString(renderInputArea(textareaView, m.width))
 		view.WriteString("\n")
 		if m.suggestion.Visible() {
 			view.WriteString(m.suggestion.View(m.width))

--- a/internal/cli/repl/repl_helpers.go
+++ b/internal/cli/repl/repl_helpers.go
@@ -148,7 +148,6 @@ func buildInitialScreen(ctx *replContext) []string {
 		"Use /help  for available commands",
 		"Use /model to change provider or model",
 		"Press Enter to send, Shift+Enter for new line",
-		"Shift+click to select and copy text",
 	}
 	tipsBox := repltheme.BoxStyle.Render(repltheme.TipStyle.Render(strings.Join(tips, "\n")))
 	lines = append(lines, tipsBox)

--- a/internal/cli/repl/viewport_selection.go
+++ b/internal/cli/repl/viewport_selection.go
@@ -1,0 +1,462 @@
+package repl
+
+import (
+	"image"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/clipperhouse/displaywidth"
+	"github.com/clipperhouse/uax29/v2/words"
+)
+
+const (
+	selectionClickThreshold = 400 * time.Millisecond
+	selectionClickTolerance = 2
+	inputPromptWidth        = 3
+)
+
+type selectionPoint struct {
+	line int
+	col  int
+}
+
+type viewportSelection struct {
+	lines []string
+
+	mouseDown bool
+	anchor    selectionPoint
+	cursor    selectionPoint
+
+	lastClickTime time.Time
+	lastClickX    int
+	lastClickY    int
+	clickCount    int
+}
+
+func (s *viewportSelection) setContent(content string) {
+	if content == "" {
+		s.lines = nil
+		return
+	}
+	s.lines = strings.Split(content, "\n")
+}
+
+func (s *viewportSelection) start(localX, localY, yOffset int) {
+	p := selectionPoint{line: clampInt(yOffset+localY, 0, max(0, len(s.lines)-1)), col: max(localX, 0)}
+	s.mouseDown = true
+	s.anchor = p
+	s.cursor = p
+}
+
+func (s *viewportSelection) drag(localX, localY, yOffset int) bool {
+	if !s.mouseDown {
+		return false
+	}
+	s.cursor = selectionPoint{line: clampInt(yOffset+localY, 0, max(0, len(s.lines)-1)), col: max(localX, 0)}
+	return true
+}
+
+func (s *viewportSelection) release() bool {
+	if !s.mouseDown {
+		return false
+	}
+	s.mouseDown = false
+	return true
+}
+
+func (s *viewportSelection) clear() {
+	s.mouseDown = false
+	s.anchor = selectionPoint{}
+	s.cursor = selectionPoint{}
+	s.clickCount = 0
+}
+
+func (s viewportSelection) hasSelection() bool {
+	return s.anchor.line != s.cursor.line || s.anchor.col != s.cursor.col
+}
+
+func (s *viewportSelection) registerClick(localX, localY int) int {
+	now := time.Now()
+	if now.Sub(s.lastClickTime) <= selectionClickThreshold &&
+		absInt(localX-s.lastClickX) <= selectionClickTolerance &&
+		absInt(localY-s.lastClickY) <= selectionClickTolerance {
+		s.clickCount++
+	} else {
+		s.clickCount = 1
+	}
+	s.lastClickTime = now
+	s.lastClickX = localX
+	s.lastClickY = localY
+	return s.clickCount
+}
+
+func (s *viewportSelection) selectWord(localX, localY, yOffset int) bool {
+	lineIndex := yOffset + localY
+	if lineIndex < 0 || lineIndex >= len(s.lines) {
+		return false
+	}
+	line := ansi.Strip(s.lines[lineIndex])
+	startCol, endCol := findSelectionWordBoundaries(line, max(localX, 0))
+	if startCol == endCol {
+		return false
+	}
+	s.mouseDown = true
+	s.anchor = selectionPoint{line: lineIndex, col: startCol}
+	s.cursor = selectionPoint{line: lineIndex, col: endCol}
+	return true
+}
+
+func (s *viewportSelection) selectLine(localY, yOffset int) bool {
+	lineIndex := yOffset + localY
+	if lineIndex < 0 || lineIndex >= len(s.lines) {
+		return false
+	}
+	lineWidth := ansi.StringWidth(s.lines[lineIndex])
+	if lineWidth == 0 {
+		return false
+	}
+	s.mouseDown = true
+	s.anchor = selectionPoint{line: lineIndex, col: 0}
+	s.cursor = selectionPoint{line: lineIndex, col: lineWidth}
+	return true
+}
+
+func (s viewportSelection) selectedText() string {
+	if !s.hasSelection() {
+		return ""
+	}
+	start, end := s.normalizedRange()
+	if len(s.lines) == 0 || start.line >= len(s.lines) {
+		return ""
+	}
+	end.line = min(end.line, len(s.lines)-1)
+
+	parts := make([]string, 0, end.line-start.line+1)
+	for lineIndex := start.line; lineIndex <= end.line; lineIndex++ {
+		line := ansi.Strip(s.lines[lineIndex])
+		lineWidth := ansi.StringWidth(line)
+		colStart := 0
+		if lineIndex == start.line {
+			colStart = clampInt(start.col, 0, lineWidth)
+		}
+		colEnd := lineWidth
+		if lineIndex == end.line {
+			colEnd = clampInt(end.col, 0, lineWidth)
+		}
+		if colEnd < colStart {
+			colStart, colEnd = colEnd, colStart
+		}
+		parts = append(parts, ansi.Cut(line, colStart, colEnd))
+	}
+	return strings.TrimRight(strings.Join(parts, "\n"), "\n")
+}
+
+func (s viewportSelection) render(view string, width, height, yOffset int) string {
+	return s.renderWithColumnOffset(view, width, height, yOffset, 0)
+}
+
+func (s viewportSelection) renderWithColumnOffset(view string, width, height, yOffset, colOffset int) string {
+	if !s.hasSelection() || width <= 0 || height <= 0 || view == "" {
+		return view
+	}
+
+	start, end := s.normalizedRange()
+	if end.line < yOffset || start.line >= yOffset+height {
+		return view
+	}
+
+	startLine := max(0, start.line-yOffset)
+	endLine := min(height-1, end.line-yOffset)
+	startCol := 0
+	if start.line >= yOffset {
+		startCol = start.col + colOffset
+	}
+	endCol := width
+	if end.line < yOffset+height {
+		endCol = end.col + colOffset
+	}
+
+	buf := uv.NewScreenBuffer(width, height)
+	uv.NewStyledString(view).Draw(&buf, image.Rect(0, 0, width, height))
+
+	for y := startLine; y <= endLine; y++ {
+		line := buf.Line(y)
+		if line == nil {
+			continue
+		}
+		colStart := 0
+		if y == startLine {
+			colStart = clampInt(startCol, 0, width)
+		}
+		colEnd := width
+		if y == endLine {
+			colEnd = clampInt(endCol, 0, width)
+		}
+
+		lastContentX := -1
+		for x := colStart; x < colEnd; x++ {
+			cell := line.At(x)
+			if cell == nil || cell.IsZero() {
+				continue
+			}
+			if cell.Content != "" && cell.Content != " " {
+				lastContentX = x
+			}
+		}
+		if lastContentX >= 0 {
+			colEnd = min(colEnd, lastContentX+1)
+		} else if colEnd == width {
+			colEnd = colStart
+		}
+
+		for x := colStart; x < colEnd; x++ {
+			cell := line.At(x)
+			if cell == nil || cell.IsZero() {
+				continue
+			}
+			cell.Style.Attrs |= uv.AttrReverse
+		}
+	}
+
+	return buf.Render()
+}
+
+func (s viewportSelection) normalizedRange() (selectionPoint, selectionPoint) {
+	start, end := s.anchor, s.cursor
+	if end.line < start.line || (end.line == start.line && end.col < start.col) {
+		start, end = end, start
+	}
+	return start, end
+}
+
+func findSelectionWordBoundaries(line string, col int) (startCol, endCol int) {
+	if line == "" || col < 0 {
+		return 0, 0
+	}
+
+	lineCol := 0
+	lastCol := 0
+	iter := words.FromString(line)
+	for iter.Next() {
+		token := iter.Value()
+		tokenWidth := displaywidth.String(token)
+		tokenStart := lineCol
+		tokenEnd := lineCol + tokenWidth
+		lineCol += tokenWidth
+
+		if col < tokenStart {
+			return lastCol, lastCol
+		}
+		lastCol = tokenEnd
+
+		if col >= tokenStart && col < tokenEnd {
+			if strings.TrimSpace(token) == "" {
+				return col, col
+			}
+			return tokenStart, tokenEnd
+		}
+	}
+
+	return col, col
+}
+
+func copySelectedTextCmd(text string) tea.Cmd {
+	if text == "" {
+		return nil
+	}
+	return tea.Sequence(
+		tea.SetClipboard(text),
+		func() tea.Msg {
+			_ = clipboard.WriteAll(text)
+			return nil
+		},
+	)
+}
+
+func isSelectionCopyKey(msg tea.KeyPressMsg) bool {
+	if msg.String() == keyCtrlC {
+		return true
+	}
+	if msg.Code != 'c' && msg.Code != 'C' {
+		return false
+	}
+	return msg.Mod.Contains(tea.ModCtrl) ||
+		msg.Mod.Contains(tea.ModSuper) ||
+		msg.Mod.Contains(tea.ModMeta)
+}
+
+func (m *replModel) handleSelectionMouseDown(msg tea.MouseClickMsg) (bool, tea.Cmd) {
+	mouse := msg.Mouse()
+	if mouse.Button != tea.MouseLeft {
+		return false, nil
+	}
+	if !m.mouseInViewport(mouse.X, mouse.Y) {
+		if m.selection.hasSelection() {
+			m.selection.clear()
+		}
+		return false, nil
+	}
+
+	clickCount := m.selection.registerClick(mouse.X, mouse.Y)
+	switch clickCount {
+	case 2:
+		if !m.selection.selectWord(mouse.X, mouse.Y, m.viewport.YOffset()) {
+			m.selection.start(mouse.X, mouse.Y, m.viewport.YOffset())
+		}
+	case 3:
+		if !m.selection.selectLine(mouse.Y, m.viewport.YOffset()) {
+			m.selection.start(mouse.X, mouse.Y, m.viewport.YOffset())
+		}
+		m.selection.clickCount = 0
+	default:
+		m.selection.start(mouse.X, mouse.Y, m.viewport.YOffset())
+	}
+	return true, nil
+}
+
+func (m *replModel) handleInputSelectionMouseDown(msg tea.MouseClickMsg) (bool, tea.Cmd) {
+	mouse := msg.Mouse()
+	if mouse.Button != tea.MouseLeft {
+		return false, nil
+	}
+	if !m.mouseInInputTextArea(mouse.X, mouse.Y) {
+		if m.inputSelection.hasSelection() {
+			m.inputSelection.clear()
+		}
+		return false, nil
+	}
+
+	m.inputSelection.setContent(m.textarea.Value())
+	m.selection.clear()
+	x, y := m.inputSelectionLocalPosition(mouse.X, mouse.Y)
+	clickCount := m.inputSelection.registerClick(x, y)
+	switch clickCount {
+	case 2:
+		if !m.inputSelection.selectWord(x, y, m.textarea.ScrollYOffset()) {
+			m.inputSelection.start(x, y, m.textarea.ScrollYOffset())
+		}
+	case 3:
+		if !m.inputSelection.selectLine(y, m.textarea.ScrollYOffset()) {
+			m.inputSelection.start(x, y, m.textarea.ScrollYOffset())
+		}
+		m.inputSelection.clickCount = 0
+	default:
+		m.inputSelection.start(x, y, m.textarea.ScrollYOffset())
+	}
+	return true, nil
+}
+
+func (m *replModel) handleSelectionMouseDrag(msg tea.MouseMotionMsg) bool {
+	if !m.selection.mouseDown {
+		return false
+	}
+	mouse := msg.Mouse()
+	if mouse.Button != tea.MouseLeft && mouse.Button != tea.MouseNone {
+		return false
+	}
+
+	localY := mouse.Y
+	if localY < 0 {
+		m.viewport.ScrollUp(1)
+		localY = 0
+	} else if localY >= m.viewport.Height() {
+		m.viewport.ScrollDown(1)
+		localY = max(0, m.viewport.Height()-1)
+	}
+	localX := clampInt(mouse.X, 0, m.viewport.Width())
+	m.selection.drag(localX, localY, m.viewport.YOffset())
+	m.userScrolled = !m.viewport.AtBottom()
+	return true
+}
+
+func (m *replModel) handleInputSelectionMouseDrag(msg tea.MouseMotionMsg) bool {
+	if !m.inputSelection.mouseDown {
+		return false
+	}
+	mouse := msg.Mouse()
+	if mouse.Button != tea.MouseLeft && mouse.Button != tea.MouseNone {
+		return false
+	}
+
+	x, y := m.inputSelectionLocalPosition(mouse.X, mouse.Y)
+	m.inputSelection.setContent(m.textarea.Value())
+	m.inputSelection.drag(x, y, m.textarea.ScrollYOffset())
+	return true
+}
+
+func (m *replModel) handleSelectionMouseUp() (bool, tea.Cmd) {
+	if !m.selection.release() {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *replModel) handleInputSelectionMouseUp() (bool, tea.Cmd) {
+	if !m.inputSelection.release() {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *replModel) handleMouseDown(msg tea.MouseClickMsg) (bool, tea.Cmd) {
+	if handled, cmd := m.handleInputSelectionMouseDown(msg); handled {
+		return true, cmd
+	}
+	return m.handleSelectionMouseDown(msg)
+}
+
+func (m *replModel) handleMouseDrag(msg tea.MouseMotionMsg) bool {
+	if m.inputSelection.mouseDown {
+		return m.handleInputSelectionMouseDrag(msg)
+	}
+	return m.handleSelectionMouseDrag(msg)
+}
+
+func (m *replModel) handleMouseUp() (bool, tea.Cmd) {
+	if m.inputSelection.mouseDown {
+		return m.handleInputSelectionMouseUp()
+	}
+	return m.handleSelectionMouseUp()
+}
+
+func (m replModel) mouseInViewport(x, y int) bool {
+	return x >= 0 && y >= 0 && x <= m.viewport.Width() && y < m.viewport.Height()
+}
+
+func (m replModel) mouseInInputTextArea(x, y int) bool {
+	inputTop := m.inputAreaTop()
+	textTop := inputTop + 1
+	return x >= 0 && y >= textTop && y < textTop+m.textarea.Height()
+}
+
+func (m replModel) inputSelectionLocalPosition(x, y int) (int, int) {
+	localY := clampInt(y-m.inputAreaTop()-1, 0, max(0, m.textarea.Height()-1))
+	localX := clampInt(x-inputPromptWidth, 0, max(0, m.textarea.Width()-inputPromptWidth))
+	return localX, localY
+}
+
+func (m replModel) inputAreaTop() int {
+	top := m.viewport.Height()
+	if m.showSpinner {
+		top += 2
+	}
+	return top
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func clampInt(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
+	return min(high, max(low, v))
+}

--- a/internal/cli/repl/viewport_selection_test.go
+++ b/internal/cli/repl/viewport_selection_test.go
@@ -1,0 +1,180 @@
+package repl
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestViewportSelection_SelectedTextAcrossLines(t *testing.T) {
+	var selection viewportSelection
+	selection.setContent("alpha beta\ngamma delta\nthird")
+	selection.start(6, 0, 0)
+	selection.drag(5, 1, 0)
+
+	if got := selection.selectedText(); got != "beta\ngamma" {
+		t.Fatalf("expected selected text, got %q", got)
+	}
+}
+
+func TestViewportSelection_SelectWord(t *testing.T) {
+	var selection viewportSelection
+	selection.setContent("hello world")
+
+	if !selection.selectWord(7, 0, 0) {
+		t.Fatal("expected word selection")
+	}
+	if got := selection.selectedText(); got != "world" {
+		t.Fatalf("expected selected word, got %q", got)
+	}
+}
+
+func TestViewportSelection_RenderHighlightsVisibleSelection(t *testing.T) {
+	var selection viewportSelection
+	selection.setContent("hello world")
+	selection.start(0, 0, 0)
+	selection.drag(5, 0, 0)
+
+	rendered := selection.render("hello world", 20, 1, 0)
+	if rendered == "hello world" {
+		t.Fatal("expected rendered selection to add styling")
+	}
+	if !strings.Contains(rendered, "hello") {
+		t.Fatalf("expected highlighted view to preserve content, got %q", rendered)
+	}
+}
+
+func TestReplSelectionMouseDragSelectsWithoutCopying(t *testing.T) {
+	m := newTestModel()
+	m.output.AddLine("hello world")
+	m.updateViewportContent()
+
+	updated, cmd := m.updateNormalMode(tea.MouseClickMsg(tea.Mouse{X: 0, Y: 0, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no command on mouse down")
+	}
+	updated, cmd = updated.updateNormalMode(tea.MouseMotionMsg(tea.Mouse{X: 5, Y: 0, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no command while dragging")
+	}
+	updated, cmd = updated.updateNormalMode(tea.MouseReleaseMsg(tea.Mouse{X: 5, Y: 0, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no copy command on mouse release")
+	}
+	if got := updated.selection.selectedText(); got != "hello" {
+		t.Fatalf("expected selected text to remain available, got %q", got)
+	}
+}
+
+func TestReplSelectionCtrlCCopiesSelection(t *testing.T) {
+	m := newTestModel()
+	m.output.AddLine("hello world")
+	m.updateViewportContent()
+	m.selection.start(0, 0, 0)
+	m.selection.drag(5, 0, 0)
+
+	updated, cmd := m.updateNormalMode(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected copy command for ctrl+c with active selection")
+	}
+	if updated.quitting {
+		t.Fatal("expected ctrl+c with selection not to quit")
+	}
+	if got := updated.selection.selectedText(); got != "hello" {
+		t.Fatalf("expected selection to remain, got %q", got)
+	}
+}
+
+func TestReplSelectionCmdCCopiesSelection(t *testing.T) {
+	m := newTestModel()
+	m.output.AddLine("hello world")
+	m.updateViewportContent()
+	m.selection.start(0, 0, 0)
+	m.selection.drag(5, 0, 0)
+
+	updated, cmd := m.updateNormalMode(tea.KeyPressMsg{Code: 'c', Mod: tea.ModSuper})
+	if cmd == nil {
+		t.Fatal("expected copy command for cmd+c with active selection")
+	}
+	if updated.quitting {
+		t.Fatal("expected cmd+c with selection not to quit")
+	}
+}
+
+func TestReplInputSelectionMouseDragSelectsWithoutCopying(t *testing.T) {
+	m := newTestModel()
+	m.textarea.SetValue("hello world")
+	textY := m.inputAreaTop() + 1
+
+	updated, cmd := m.updateNormalMode(tea.MouseClickMsg(tea.Mouse{X: inputPromptWidth, Y: textY, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no command on input mouse down")
+	}
+	updated, cmd = updated.updateNormalMode(tea.MouseMotionMsg(tea.Mouse{X: inputPromptWidth + 5, Y: textY, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no command while dragging input selection")
+	}
+	updated, cmd = updated.updateNormalMode(tea.MouseReleaseMsg(tea.Mouse{X: inputPromptWidth + 5, Y: textY, Button: tea.MouseLeft}))
+	if cmd != nil {
+		t.Fatal("expected no copy command on input mouse release")
+	}
+	if got := updated.inputSelection.selectedText(); got != "hello" {
+		t.Fatalf("expected input selection to remain, got %q", got)
+	}
+	if strings.Contains(updated.selection.selectedText(), "hello") {
+		t.Fatalf("expected viewport selection to stay clear, got %q", updated.selection.selectedText())
+	}
+}
+
+func TestReplInputSelectionCtrlCCopiesSelection(t *testing.T) {
+	m := newTestModel()
+	m.textarea.SetValue("hello world")
+	m.inputSelection.setContent(m.textarea.Value())
+	m.inputSelection.start(0, 0, 0)
+	m.inputSelection.drag(5, 0, 0)
+
+	updated, cmd := m.updateNormalMode(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("expected copy command for ctrl+c with active input selection")
+	}
+	if updated.quitting {
+		t.Fatal("expected ctrl+c with input selection not to quit")
+	}
+	if got := updated.inputSelection.selectedText(); got != "hello" {
+		t.Fatalf("expected input selection to remain, got %q", got)
+	}
+}
+
+func TestView_RendersInputSelection(t *testing.T) {
+	m := newTestModel()
+	m.textarea.SetValue("hello world")
+	m.inputSelection.setContent(m.textarea.Value())
+	m.inputSelection.start(0, 0, 0)
+	m.inputSelection.drag(5, 0, 0)
+
+	view := m.View().Content
+	plainView := ansi.Strip(view)
+	if !strings.Contains(plainView, "hello") {
+		t.Fatalf("expected input content in view, got %q", view)
+	}
+	withoutSelection := newTestModel()
+	withoutSelection.textarea.SetValue("hello world")
+	if view == withoutSelection.View().Content {
+		t.Fatal("expected input selection to affect rendered view")
+	}
+}
+
+func TestView_KeepsAltScreenMouseCaptureForSelection(t *testing.T) {
+	m := newTestModel()
+
+	view := m.View()
+
+	if !view.AltScreen {
+		t.Fatal("expected alt-screen to remain enabled")
+	}
+	if view.MouseMode != tea.MouseModeCellMotion {
+		t.Fatalf("expected cell motion mouse capture, got %v", view.MouseMode)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

- add mouse selection for viewport and input text
- copy active selection with Ctrl+C or forwarded Cmd+C
- remove outdated Shift-click selection tip

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New tool
- [ ] New provider or model
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] `go test ./...` passes
- [x] `go mod tidy` has been run
- [x] New behavior is covered by tests where it makes sense
- [ ] For new providers: entry added to `providers/registry.yaml` with correct `context_window`