### PR TITLE
feat(skills): require frontmatter and support argument substitution

### DIFF
--- a/.agents/skills/echo/SKILL.md
+++ b/.agents/skills/echo/SKILL.md
@@ -10,6 +10,6 @@ When this skill is activated:
 1. Read this SKILL.md file first.
 2. Reply with exactly these fields in exact format as XML:
    - `skill`: `echo`
-   - `args`: the activation arguments exactly as provided
+   - `args`: $ARGUMENTS
    - `skill_file`: this SKILL.md path
 3. Do not edit files or run shell commands.

--- a/.agents/skills/echo/SKILL.md
+++ b/.agents/skills/echo/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: echo
+description: Echo the invocation arguments and identify the skill file path in XML format.
+---
+
+# Echo Skill
+
+When this skill is activated:
+
+1. Read this SKILL.md file first.
+2. Reply with exactly these fields in exact format as XML:
+   - `skill`: `echo`
+   - `args`: the activation arguments exactly as provided
+   - `skill_file`: this SKILL.md path
+3. Do not edit files or run shell commands.

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: git-commit
+description: Stage, commit, and push changes with an auto-generated commit message.
+---
+
+# Git Commit Skill
+
+## Steps
+
+1. Run `git status --short` to see the current state of the working tree.
+
+2. Stage all tracked modifications:
+   ```
+   git add -u
+   ```
+
+3. If there are untracked files listed in step 1, show them to the user and ask:
+   > "The following untracked files were found. Should any of them be included in this commit?"
+   > (list the files)
+   Wait for the user's response before continuing. Add only the files the user confirms.
+
+4. Run `git diff --staged --stat` to review what is staged. If nothing is staged, tell the user and stop.
+
+5. Inspect the staged diff to write a concise commit message:
+   - First line: `type(scope): short summary` (50 chars or fewer)
+   - Use types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+   - Add bullet points outlining the important changes
+   - Never add co-author or AI attribution lines
+
+6. Show the proposed commit message to the user and ask for confirmation or edits before committing.
+
+7. Once confirmed, commit:
+   ```
+   git commit -m "<message>"
+   ```
+
+8. Ask the user whether to push. If yes, run:
+   ```
+   git push
+   ```
+   If the push is rejected because the remote branch does not exist yet, re-run with `--set-upstream origin <branch>`.
+
+## Constraints
+
+- Never run `git reset`, `git rebase`, or `git push --force`.
+- Never commit files that look like they contain secrets (`.env`, credentials, private keys).
+- If the user provided arguments when invoking this skill, treat them as additional context or instructions for the commit message.

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-commit
+name: commit
 description: Stage, commit, and push changes with an auto-generated commit message.
 ---
 

--- a/.ai-interactions/tasks/issue-34/output-1_agent-skills-rfc.md
+++ b/.ai-interactions/tasks/issue-34/output-1_agent-skills-rfc.md
@@ -1,0 +1,270 @@
+# RFC: Agent Skills Support in Keen Code
+
+## Summary
+
+Add support for the [Agent Skills open standard](https://agentskills.io/client-implementation/adding-skills-support.md) in Keen Code. Skills are markdown files with YAML frontmatter that extend the agent's capabilities. They follow **progressive disclosure**: a lightweight catalog in the system prompt, full instructions loaded on demand via `read_file`, and resources referenced as needed.
+
+---
+
+## Discovery
+
+Keen scans two directories on session start:
+
+| Level | Path |
+|-------|------|
+| Project | `<working_dir>/.agents/skills/` |
+| Global | `~/.agents/skills/` |
+
+Each subdirectory containing a `SKILL.md` file is a skill. The directory name is the skill name.
+
+**Collision resolution:** If the same skill name exists at both levels, the project-level skill wins.
+
+**Live reload:** Since `Build()` scans skill directories on every call, catalog changes
+(add, remove, rename) are reflected on the next message. Content changes are always
+fresh since the model reads `SKILL.md` via `read_file` at invocation time.
+
+---
+
+## Parsing
+
+Each `SKILL.md` is parsed for:
+
+1. **YAML frontmatter** — delimited by `---` at the top of the file
+2. **Markdown body** — everything after the closing `---`
+
+### Supported frontmatter fields
+
+| Field | Required | Source | Description |
+|-------|----------|--------|-------------|
+| `name` | Yes | User | Skill name (used for display, must match directory name) |
+| `description` | Yes | User | Short description for the catalog |
+
+For each skill, the parser will generate a `location` field with the absolute path to the `SKILL.md` file. This is used to access the skill by the model.
+
+All other user-provided fields are **ignored**.
+
+### Validation
+
+Per the open standard — **lenient**. Warn on minor issues but don't block loading:
+- Missing `name` or `description` → warn, use directory name as fallback
+- Unparseable YAML frontmatter → skill is **not loaded**; error message shown to user: `Skill <skill-name> failed to load due to YAML parsing issue`
+- `location` is **auto-generated** by the parser (absolute path to the `SKILL.md` file), never read from user-provided YAML
+
+---
+
+## Progressive Disclosure
+
+### Tier 1: Catalog (system prompt)
+
+A bulleted list of all **enabled** skills is injected into the system prompt on every turn:
+
+```
+## Available Skills
+
+You have access to specialized skills. To activate a skill, read its SKILL.md file
+using the read_file tool, then follow the instructions within.
+
+- my-skill: Brief description of what it does
+- another-skill: Another description
+```
+
+If no skills are found, nothing is added.
+
+### Tier 2: Instructions (on activation)
+
+The model activates a skill by calling `read_file` on the skill's `SKILL.md` path. The skill body contains instructions the model follows.
+
+### Tier 3: Resources
+
+Skill instructions may reference files relative to the skill root directory. The model accesses these via standard tools.
+
+---
+
+## Skill Invocation
+
+### Model-driven invocation
+
+The model reads the catalog and decides when a skill is relevant. It invokes the skill by using `read_file` on that skill's `SKILL.md`.
+
+### User-driven invocation (`/<skill-name>`)
+
+When the user types `/<skill-name> [arguments...]`, the REPL intercepts this:
+
+1. Look up the skill by name
+2. Read the `SKILL.md` file
+3. **Substitute argument placeholders** in the content (Claude Code convention):
+   - `$ARGUMENTS` → all arguments joined with spaces
+   - `$ARGUMENTS[N]` → single argument at index N (0-based, e.g., `$ARGUMENTS[0]` for first arg)
+   - `$0`, `$1`, `$2`, ... `$9` → positional arguments (`$0` is the first argument)
+   - If arguments are provided but none of the above placeholders appear in the content, they are silently ignored
+4. Inject the processed content as a user message prefixed with context:
+
+```
+[Activated skill: my-skill]
+Arguments: foo bar
+
+<processed SKILL.md content>
+```
+
+The model then follows the instructions within.
+
+---
+
+## `/skills` REPL Command
+
+A meta-command for managing skills. Intercepted by the REPL before LLM dispatch.
+
+### `/skills list`
+
+Displays all discovered skills with their status:
+
+```
+  Available Skills:
+    my-skill        ✓ enabled  - Brief description
+    another-skill   ✗ disabled - Another description
+```
+
+### `/skills <name> enable`
+
+Enables a skill.
+
+Confirmation: `  ✓ Skill "my-skill" enabled`
+
+### `/skills <name> disable`
+
+Disables a skill.
+
+Confirmation: `  ✓ Skill "my-skill" disabled`
+
+---
+
+## Config Persistence
+
+Skill enable/disable state is stored in `~/.keen/skills/config.json`:
+
+```json
+{
+  "is_enabled": {
+    "my-skill": true,
+    "another-skill": false
+  }
+}
+```
+---
+
+## System Prompt Changes
+
+The `llm.Build()` function is extended to scan skills directories and append
+the catalog. No signature change — callers remain unchanged.
+
+`Build()` internally:
+
+1. Scans `.agents/skills/` (project + global) for `SKILL.md` files
+2. Loads `~/.keen/skills/config.json` for enable/disable state
+3. Builds the catalog string and appends it after project instructions
+
+The catalog section instructs the model on how to access skills:
+
+```
+## Available Skills
+
+You have access to specialized skills. To activate a skill, use the read_file
+tool to read the skill's SKILL.md file at one of these paths, then follow the
+instructions within:
+
+- my-skill: Brief description → read /absolute/path/to/project/.agents/skills/my-skill/SKILL.md
+- another-skill: Another description → read /home/user/.agents/skills/another-skill/SKILL.md
+```
+
+### Disabled skills
+
+Disabled skills are **not** included in the system prompt catalog. They are only visible via `/skills list`.
+
+---
+
+## File References in Skills
+
+All file paths in skill instructions are relative to the skill's root directory (the directory containing `SKILL.md`). For example, if `SKILL.md` references `scripts/helper.sh`, the full path is:
+
+```
+.agents/skills/my-skill/scripts/helper.sh
+```
+
+The model is instructed in the catalog to resolve relative paths against the skill directory.
+
+---
+
+## Guard Allowlist for Skill Roots
+
+The filesystem guard currently blocks global skills in two ways:
+
+1. **`~/.agents` is blocked** — `guard.go:55` blocks all `~/.*` paths
+2. **`PermissionPending` for reads outside working dir** — `CheckPath` returns `PermissionPending` for read operations outside the working directory, prompting the user on every invocation
+
+To fix this, the guard gains an allowlist of discovered skill roots:
+
+- `Guard` gets an `AddAllowlistRoot(path string)` method
+- `CheckPath` treats any path within an allowlisted root as `PermissionGranted` for read operations, even outside the working dir
+- The REPL passes discovered skill root directories to the guard after scanning, on every `Build()` call
+
+This covers not only `SKILL.md` files but also any bundled resources (scripts, references) within the skill directory.
+
+---
+
+## Implementation Plan
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `internal/skills/discover.go` | Scan directories, find `SKILL.md` files |
+| `internal/skills/parse.go` | Parse YAML frontmatter + markdown body |
+| `internal/skills/catalog.go` | Build catalog string for system prompt |
+| `internal/skills/config.go` | Load/save `~/.keen/skills/config.json` |
+| `internal/skills/invoke.go` | Handle `/<skill-name>` argument substitution |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/llm/systemprompt.go` | Accept and append skills catalog |
+| `internal/filesystem/guard.go` | Add allowlist for skill roots; override `~/.*` block + `PermissionPending` for allowed paths |
+| `internal/cli/repl/commands/commands.go` | Add `/skills` command |
+| `internal/cli/repl/command_handlers.go` | Handle `/skills list/enable/disable` |
+| `internal/cli/repl/repl.go` | No changes needed (skills loaded on-demand by `Build()`) |
+| `internal/cli/repl/handlers.go` | Intercept `/<skill-name>` before LLM dispatch |
+| `internal/cli/repl/widgets/suggestion.go` | Auto-complete skill names after `/` |
+| `internal/cli/repl/appstate/state.go` | Pass allowlisted skill roots to guard on each `Build()` call |
+
+### Tests
+
+| File | Purpose |
+|------|---------|
+| `internal/skills/discover_test.go` | Discovery with various directory layouts |
+| `internal/skills/parse_test.go` | YAML parsing, validation, edge cases |
+| `internal/skills/catalog_test.go` | Catalog generation, empty states |
+| `internal/skills/config_test.go` | Config load/save, defaults |
+| `internal/skills/invoke_test.go` | Argument substitution |
+| `internal/filesystem/guard_test.go` | Allowlist grants read access to skill roots outside working dir, blocks `~/.*` paths that aren't allowlisted |
+| `internal/cli/repl/command_handlers_test.go` | `/skills` command behavior |
+| `internal/llm/systemprompt_test.go` | Catalog injection |
+
+---
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| No `.agents/skills/` directory exists | No skills loaded, no catalog injected |
+| `SKILL.md` has no YAML frontmatter | Treated as plain markdown; use directory name as skill name |
+| `SKILL.md` has unparseable YAML frontmatter | Skill is not loaded; error message: `Skill <skill-name> failed to load due to YAML parsing issue` |
+| `SKILL.md` is empty | Skill is skipped |
+| Skill directory contains only `SKILL.md` (no resources) | Valid; catalog entry created normally |
+| Same skill name in project and global | Project wins; global version is shadowed |
+| User disables a skill, then removes the directory | Config key becomes orphaned (harmless — cleaned up if skill reappears) |
+| `/<skill-name>` with no matching skill | Pass through to LLM as regular text (model may ignore or respond) |
+| Skill with `$ARGUMENTS` but no arguments passed | `$ARGUMENTS` replaced with empty string |
+| Skill invoked with arguments but no placeholder in content | Arguments are silently ignored |
+| Project changes during session | Reflected on next message (catalog rescanned each turn) |
+| Model tries to `read_file` a global skill | Guard allowlists discovered skill roots; reads granted automatically |
+| Skill references a bundled resource (e.g., `scripts/foo.sh`) | Guard allows read because path is within allowlisted skill root |

--- a/.ai-interactions/tasks/issue-34/prompt-1_agent-skills.md
+++ b/.ai-interactions/tasks/issue-34/prompt-1_agent-skills.md
@@ -1,0 +1,22 @@
+## Supporting Skills in Keen Code
+
+1. Hi, check the issue: https://github.com/mochow13/keen-code/issues/34. Don't do any work. Just read it.
+2. Now review the two linked specificiations.
+3. Does open standard not support arguments?
+4. We want to support skills in Keen Code. Following are the requirements we need to implement:
+    - Keen will look for skills according to the open standard in `.agents` directory both for global and project level
+    - Skills will be loaded according to the open standard (progressive disclosure)
+    - Collisions, parsing, validation will be handled by the open standard
+    - Skill catalog should be simple bulleted list with name and description only. No other fields.
+    - Catalog should be placed in the system prompt
+    - Instruct the model in the system prompt on how to access individual skills using `read_file` tool
+    - If no skill is found, nothing will be added to the system prompt
+    - Skills can be invoked by `/<skill-name>` or by models naturally deciding to invoke it
+    - For now, skills will support only these frontmatter fields: `name`, `description`, `location`. Other fields will be ignored.
+    - Skills will also support arguments. We will follow the Claude Code approach for this
+    - File references will be relative to the skill root directory
+    - `/skills` is a REPL command that will be used to manage skills
+    - User can enable/disable skills by simply running a command `/skills <skill-name> <enable|disable>`
+    - Enable/disable operation will show a confirmation message to the user
+    - Enabled/disabled skills will be persisted across sessions, so we need to store them in a config in ~/.keen/skills/config.json
+    - `/skills list` will list all available skills along with their status

--- a/internal/cli/repl/appstate/state.go
+++ b/internal/cli/repl/appstate/state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/user/keen-code/internal/config"
 	"github.com/user/keen-code/internal/llm"
+	"github.com/user/keen-code/internal/skills"
 	"github.com/user/keen-code/internal/tools"
 )
 
@@ -18,15 +19,19 @@ type AppState struct {
 	toolRegistry *tools.Registry
 	workingDir   string
 	lastUsage    *llm.TokenUsage
+	skills       skills.Discovery
+	skillsConfig skills.Config
 }
 
 func New(client llm.LLMClient, workingDir string) *AppState {
-	return &AppState{
+	state := &AppState{
 		messages:     []llm.Message{},
 		llmClient:    client,
 		toolRegistry: tools.NewRegistry(),
 		workingDir:   workingDir,
 	}
+	state.ReloadSkills()
+	return state
 }
 
 func (s *AppState) AddMessage(role llm.Role, content string) {
@@ -48,6 +53,68 @@ func (s *AppState) ClearMessages() {
 	s.messages = []llm.Message{}
 }
 
+func (s *AppState) ReloadSkills() skills.Discovery {
+	if strings.TrimSpace(s.workingDir) == "" {
+		s.skills = skills.Discovery{}
+		s.skillsConfig = skills.LoadConfig()
+		return s.GetSkills()
+	}
+	s.skills = skills.LoadMetadata(skills.Discover(s.workingDir))
+	s.skillsConfig = skills.LoadConfig()
+	return s.GetSkills()
+}
+
+func (s *AppState) GetSkills() skills.Discovery {
+	return skills.Discovery{
+		Skills:   append([]skills.Skill(nil), s.skills.Skills...),
+		Warnings: append([]string(nil), s.skills.Warnings...),
+	}
+}
+
+func (s *AppState) GetSkillsConfig() skills.Config {
+	return cloneSkillsConfig(s.skillsConfig)
+}
+
+func (s *AppState) SetSkillEnabled(name string, enabled bool) error {
+	cfg := cloneSkillsConfig(s.skillsConfig)
+	cfg.SetEnabled(name, enabled)
+	if err := skills.SaveConfig(cfg); err != nil {
+		return err
+	}
+	s.skillsConfig = cfg
+	return nil
+}
+
+func (s *AppState) FindEnabledSkill(name string) (skills.Skill, bool) {
+	skill, ok := skills.Find(s.skills.Skills, name)
+	if !ok || !s.skillsConfig.Enabled(skill.Name) {
+		return skills.Skill{}, false
+	}
+	return skill, true
+}
+
+func (s *AppState) SkillSuggestions() []skills.Skill {
+	items := make([]skills.Skill, 0, len(s.skills.Skills))
+	for _, skill := range s.skills.Skills {
+		if s.skillsConfig.Enabled(skill.Name) {
+			items = append(items, skill)
+		}
+	}
+	return items
+}
+
+func (s *AppState) SkillsCatalog() string {
+	return skills.Catalog(s.skills.Skills, s.skillsConfig)
+}
+
+func cloneSkillsConfig(cfg skills.Config) skills.Config {
+	cloned := skills.Config{IsEnabled: map[string]bool{}}
+	for name, enabled := range cfg.IsEnabled {
+		cloned.IsEnabled[name] = enabled
+	}
+	return cloned
+}
+
 func (s *AppState) ResetClientState() {
 	if s.llmClient != nil {
 		s.llmClient.Reset()
@@ -64,7 +131,7 @@ func (s *AppState) StreamChat(ctx context.Context, cfg *config.ResolvedConfig) (
 	}
 	systemMsg := llm.Message{
 		Role:    llm.RoleSystem,
-		Content: llm.Build(s.workingDir),
+		Content: llm.Build(s.workingDir, s.SkillsCatalog()),
 	}
 	messages := append([]llm.Message{systemMsg}, s.GetMessages()...)
 	return s.llmClient.StreamChat(ctx, messages, s.toolRegistry)

--- a/internal/cli/repl/appstate/state.go
+++ b/internal/cli/repl/appstate/state.go
@@ -48,6 +48,12 @@ func (s *AppState) ClearMessages() {
 	s.messages = []llm.Message{}
 }
 
+func (s *AppState) ResetClientState() {
+	if s.llmClient != nil {
+		s.llmClient.Reset()
+	}
+}
+
 func (s *AppState) ReplaceMessages(messages []llm.Message) {
 	s.messages = llm.CloneMessages(messages)
 }

--- a/internal/cli/repl/appstate/state_test.go
+++ b/internal/cli/repl/appstate/state_test.go
@@ -13,6 +13,7 @@ import (
 
 type mockLLMClient struct {
 	streamChatFunc func(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry) (<-chan llm.StreamEvent, error)
+	resetCount     int
 }
 
 func (m *mockLLMClient) StreamChat(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry) (<-chan llm.StreamEvent, error) {
@@ -22,6 +23,10 @@ func (m *mockLLMClient) StreamChat(ctx context.Context, messages []llm.Message, 
 	ch := make(chan llm.StreamEvent)
 	close(ch)
 	return ch, nil
+}
+
+func (m *mockLLMClient) Reset() {
+	m.resetCount++
 }
 
 func TestNewAppState(t *testing.T) {
@@ -136,6 +141,23 @@ func TestAppState_ClearMessages_EmptyState(t *testing.T) {
 	if len(state.messages) != 0 {
 		t.Errorf("expected 0 messages, got %d", len(state.messages))
 	}
+}
+
+func TestAppState_ResetClientState(t *testing.T) {
+	client := &mockLLMClient{}
+	state := New(client, t.TempDir())
+
+	state.ResetClientState()
+
+	if client.resetCount != 1 {
+		t.Fatalf("expected reset once, got %d", client.resetCount)
+	}
+}
+
+func TestAppState_ResetClientState_NilClient(t *testing.T) {
+	state := New(nil, t.TempDir())
+
+	state.ResetClientState()
 }
 
 func TestAppState_StreamChat_WithClient(t *testing.T) {

--- a/internal/cli/repl/appstate/state_test.go
+++ b/internal/cli/repl/appstate/state_test.go
@@ -3,6 +3,8 @@ package appstate
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -143,6 +145,76 @@ func TestAppState_ClearMessages_EmptyState(t *testing.T) {
 	}
 }
 
+func TestAppState_ReloadSkillsCachesMetadataOnly(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	body := "---\nname: demo\ndescription: Demo skill\n---\nSecret instruction body"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(body), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	state := New(nil, work)
+	discovery := state.GetSkills()
+	if len(discovery.Skills) != 1 {
+		t.Fatalf("expected one cached skill, got %#v", discovery.Skills)
+	}
+	if discovery.Skills[0].Description != "Demo skill" {
+		t.Fatalf("expected metadata description, got %#v", discovery.Skills[0])
+	}
+	if strings.Contains(state.SkillsCatalog(), "Secret instruction body") {
+		t.Fatal("expected cached catalog to exclude instruction body")
+	}
+}
+
+func TestAppState_SkillsReloadUpdatesMetadata(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	state := New(nil, work)
+	if len(state.GetSkills().Skills) != 0 {
+		t.Fatal("expected no initial skills")
+	}
+
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	state.ReloadSkills()
+	if _, ok := state.FindEnabledSkill("demo"); !ok {
+		t.Fatal("expected reloaded skill")
+	}
+}
+
+func TestAppState_SetSkillEnabledUpdatesCachedConfig(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	state := New(nil, work)
+	if err := state.SetSkillEnabled("demo", false); err != nil {
+		t.Fatalf("SetSkillEnabled() error = %v", err)
+	}
+	if _, ok := state.FindEnabledSkill("demo"); ok {
+		t.Fatal("expected disabled skill to be hidden")
+	}
+}
+
 func TestAppState_ResetClientState(t *testing.T) {
 	client := &mockLLMClient{}
 	state := New(client, t.TempDir())
@@ -165,9 +237,11 @@ func TestAppState_StreamChat_WithClient(t *testing.T) {
 		{Type: llm.StreamEventTypeChunk, Content: "Hello"},
 		{Type: llm.StreamEventTypeDone},
 	}
+	var capturedMessages []llm.Message
 
 	client := &mockLLMClient{
 		streamChatFunc: func(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry) (<-chan llm.StreamEvent, error) {
+			capturedMessages = append([]llm.Message(nil), messages...)
 			ch := make(chan llm.StreamEvent)
 			go func() {
 				defer close(ch)
@@ -179,7 +253,18 @@ func TestAppState_StreamChat_WithClient(t *testing.T) {
 		},
 	}
 
-	state := New(client, t.TempDir())
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	state := New(client, work)
 	state.AddMessage(llm.RoleUser, "Hi")
 
 	cfg := &config.ResolvedConfig{APIKey: "key", Model: "model"}
@@ -195,6 +280,12 @@ func TestAppState_StreamChat_WithClient(t *testing.T) {
 
 	if len(received) != len(expectedEvents) {
 		t.Errorf("expected %d events, got %d", len(expectedEvents), len(received))
+	}
+	if len(capturedMessages) == 0 || capturedMessages[0].Role != llm.RoleSystem {
+		t.Fatalf("expected system message, got %#v", capturedMessages)
+	}
+	if !strings.Contains(capturedMessages[0].Content, "- demo: Demo skill") {
+		t.Fatalf("expected cached skills catalog in system prompt, got %q", capturedMessages[0].Content)
 	}
 }
 

--- a/internal/cli/repl/command_handlers.go
+++ b/internal/cli/repl/command_handlers.go
@@ -7,12 +7,14 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
 	keenauth "github.com/user/keen-code/internal/auth"
 	replcommands "github.com/user/keen-code/internal/cli/repl/commands"
 	reploutput "github.com/user/keen-code/internal/cli/repl/output"
 	repltheme "github.com/user/keen-code/internal/cli/repl/theme"
 	replwidgets "github.com/user/keen-code/internal/cli/repl/widgets"
 	"github.com/user/keen-code/internal/config"
+	"github.com/user/keen-code/internal/skills"
 )
 
 func (m *replModel) dispatchCommand(input string) (replModel, tea.Cmd, bool) {
@@ -23,7 +25,7 @@ func (m *replModel) dispatchCommand(input string) (replModel, tea.Cmd, bool) {
 		return *m, tea.Quit, true
 
 	case input == replcommands.Help:
-		m.output.AddLine(getHelpText())
+		m.output.AddLine(getHelpText(m.helpWidth()))
 		m.output.AddEmptyLine()
 		m.textarea.Reset()
 		m.updateViewportContent()
@@ -73,6 +75,11 @@ func (m *replModel) dispatchCommand(input string) (replModel, tea.Cmd, bool) {
 	case input == replcommands.ShowThinking || strings.HasPrefix(input, replcommands.ShowThinking+" "):
 		m.textarea.Reset()
 		result := m.handleShowThinkingCommand(input)
+		return result, nil, true
+
+	case input == replcommands.Skills || strings.HasPrefix(input, replcommands.Skills+" "):
+		m.textarea.Reset()
+		result := m.handleSkillsCommand(input)
 		return result, nil, true
 
 	case input == replcommands.Compact || strings.HasPrefix(input, replcommands.Compact+" "):
@@ -213,6 +220,162 @@ func (m *replModel) handleShowThinkingCommand(input string) replModel {
 	return *m
 }
 
+func (m *replModel) handleSkillsCommand(input string) replModel {
+	args := strings.Fields(strings.TrimSpace(strings.TrimPrefix(input, replcommands.Skills)))
+	discovery := m.appState.GetSkills()
+	cfg := m.appState.GetSkillsConfig()
+
+	for _, warning := range discovery.Warnings {
+		m.output.AddError(warning, repltheme.ErrorStyle)
+	}
+
+	if len(args) == 0 || (len(args) == 1 && args[0] == "list") {
+		m.output.AddStyledLine("  Available Skills\n", lipgloss.NewStyle().Foreground(repltheme.MutedColor).Bold(true))
+		if len(discovery.Skills) == 0 {
+			m.output.AddStyledLine("    No skills found.", lipgloss.NewStyle().Foreground(repltheme.MutedColor))
+		} else {
+			m.addSkillTable(discovery.Skills, cfg)
+		}
+		m.output.AddEmptyLine()
+		m.updateViewportContent()
+		m.viewport.GotoBottom()
+		return *m
+	}
+
+	if len(args) == 1 && args[0] == "reload" {
+		discovery = m.appState.ReloadSkills()
+		for _, warning := range discovery.Warnings {
+			m.output.AddError(warning, repltheme.ErrorStyle)
+		}
+		m.output.AddStyledLine("  ✓ Skills reloaded", repltheme.HighlightStyle)
+		m.output.AddEmptyLine()
+		m.updateViewportContent()
+		m.viewport.GotoBottom()
+		return *m
+	}
+
+	if len(args) != 2 || (args[1] != "enable" && args[1] != "disable") {
+		m.output.AddError("Usage: /skills list | /skills reload | /skills <name> enable|disable", repltheme.ErrorStyle)
+		m.updateViewportContent()
+		m.viewport.GotoBottom()
+		return *m
+	}
+
+	name := args[0]
+	if _, ok := skills.Find(discovery.Skills, name); !ok {
+		m.output.AddError("Skill not found: "+name, repltheme.ErrorStyle)
+		m.updateViewportContent()
+		m.viewport.GotoBottom()
+		return *m
+	}
+
+	enabled := args[1] == "enable"
+	if err := m.appState.SetSkillEnabled(name, enabled); err != nil {
+		m.output.AddError("Failed to save skills config: "+err.Error(), repltheme.ErrorStyle)
+		m.updateViewportContent()
+		m.viewport.GotoBottom()
+		return *m
+	}
+
+	if enabled {
+		m.output.AddStyledLine("  ✓ Skill \""+name+"\" enabled", repltheme.HighlightStyle)
+	} else {
+		m.output.AddStyledLine("  ✓ Skill \""+name+"\" disabled", repltheme.HighlightStyle)
+	}
+	m.output.AddEmptyLine()
+	m.updateViewportContent()
+	m.viewport.GotoBottom()
+	return *m
+}
+
+func (m *replModel) addSkillTable(skillList []skills.Skill, cfg skills.Config) {
+	const (
+		leftPadding  = "    "
+		rightPadding = 2
+		cellPadding  = 2
+	)
+
+	nameWidth := maxSkillNameWidth(skillList)
+	if nameWidth < len("Skill") {
+		nameWidth = len("Skill")
+	}
+	statusWidth := max(lipgloss.Width("Status"), lipgloss.Width("✗ disabled"))
+	tableWidth := m.width - lipgloss.Width(leftPadding) - rightPadding
+	if tableWidth < 1 {
+		tableWidth = m.viewport.Width() - lipgloss.Width(leftPadding) - rightPadding
+	}
+	if tableWidth < 1 {
+		tableWidth = 1
+	}
+
+	rows := make([][]string, 0, len(skillList))
+	for _, skill := range skillList {
+		status := "✓ enabled"
+		if !cfg.Enabled(skill.Name) {
+			status = "✗ disabled"
+		}
+		rows = append(rows, []string{skill.Name, status, skill.Description})
+	}
+
+	headerStyle := lipgloss.NewStyle().Foreground(repltheme.MutedColor).Bold(true)
+	nameStyle := lipgloss.NewStyle().Foreground(repltheme.PrimaryColor).Bold(true)
+	disabledStatusStyle := lipgloss.NewStyle().Foreground(repltheme.AccentColor)
+
+	rendered := table.New().
+		Headers("Skill", "Status", "Description").
+		Rows(rows...).
+		Width(tableWidth).
+		Wrap(true).
+		Border(lipgloss.NormalBorder()).
+		BorderTop(false).
+		BorderBottom(false).
+		BorderLeft(false).
+		BorderRight(false).
+		BorderColumn(false).
+		BorderRow(false).
+		BorderHeader(true).
+		BorderStyle(repltheme.RuleStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			style := lipgloss.NewStyle().PaddingRight(cellPadding)
+			if row == table.HeaderRow {
+				style = style.Inherit(headerStyle)
+			}
+			if col == 0 {
+				style = style.Width(nameWidth + cellPadding)
+				if row != table.HeaderRow {
+					style = style.Inherit(nameStyle)
+				}
+			}
+			if col == 1 {
+				style = style.Width(statusWidth + cellPadding)
+				if row != table.HeaderRow {
+					if strings.HasPrefix(rows[row][col], "✓") {
+						style = style.Inherit(repltheme.HighlightStyle)
+					} else {
+						style = style.Inherit(disabledStatusStyle)
+					}
+				}
+			}
+			if col == 2 && row != table.HeaderRow {
+				style = style.Inherit(repltheme.HelpDescStyle)
+			}
+			return style
+		}).
+		Render()
+
+	for _, line := range strings.Split(rendered, "\n") {
+		m.output.AddLine(leftPadding + line)
+	}
+}
+
+func maxSkillNameWidth(skillList []skills.Skill) int {
+	width := 0
+	for _, skill := range skillList {
+		width = max(width, lipgloss.Width(skill.Name))
+	}
+	return width
+}
+
 func (m *replModel) saveShowThinking(val bool) {
 	if m.ctx == nil || m.ctx.globalCfg == nil || m.ctx.loader == nil {
 		return
@@ -273,13 +436,56 @@ func (m *replModel) handleClearCommand() replModel {
 	return *m
 }
 
-func getHelpText() string {
+func (m *replModel) helpWidth() int {
+	width := m.width
+	if width <= 0 {
+		width = m.viewport.Width()
+	}
+	if width <= 0 {
+		width = 80
+	}
+	return width
+}
+
+func getHelpText(width int) string {
+	const (
+		leftPadding  = "  "
+		rightPadding = 2
+		colGap       = "  "
+	)
+
+	cmdWidth := maxCommandNameWidth(replcommands.All)
+	if cmdWidth < len("Command") {
+		cmdWidth = len("Command")
+	}
+	descWidth := width - lipgloss.Width(leftPadding) - cmdWidth - lipgloss.Width(colGap) - rightPadding
+	if descWidth < 1 {
+		descWidth = 1
+	}
+
 	var lines []string
-	lines = append(lines, repltheme.TitleStyle.Render("Available Commands"))
+	lines = append(lines, leftPadding+repltheme.TitleStyle.Render("Available Commands"))
 	lines = append(lines, "")
 	for _, c := range replcommands.All {
-		lines = append(lines, "  "+repltheme.HelpCmdStyle.Render(c.Name)+" "+repltheme.HelpDescStyle.Render(c.Description))
+		descriptionLines := strings.Split(lipgloss.NewStyle().Width(descWidth).Render(c.Description), "\n")
+		if len(descriptionLines) == 0 {
+			descriptionLines = []string{""}
+		}
+
+		lines = append(lines, leftPadding+repltheme.HelpCmdStyle.Width(cmdWidth).Render(c.Name)+colGap+repltheme.HelpDescStyle.Render(descriptionLines[0]))
+		continuation := leftPadding + strings.Repeat(" ", cmdWidth) + colGap
+		for _, line := range descriptionLines[1:] {
+			lines = append(lines, continuation+repltheme.HelpDescStyle.Render(line))
+		}
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func maxCommandNameWidth(commands []replcommands.SlashCommand) int {
+	width := 0
+	for _, command := range commands {
+		width = max(width, lipgloss.Width(command.Name))
+	}
+	return width
 }

--- a/internal/cli/repl/command_handlers.go
+++ b/internal/cli/repl/command_handlers.go
@@ -250,6 +250,7 @@ func (m *replModel) handleLogoutCommand() replModel {
 
 func (m *replModel) handleClearCommand() replModel {
 	m.appState.ClearMessages()
+	m.appState.ResetClientState()
 	m.appState.ClearContextMetrics()
 	m.sessions.resetSession()
 	if m.permissionRequester != nil {

--- a/internal/cli/repl/command_handlers_test.go
+++ b/internal/cli/repl/command_handlers_test.go
@@ -207,6 +207,9 @@ func TestDispatchCommand_SlashPrefixedNonCommandFallsThrough(t *testing.T) {
 
 func TestHandleEnterKey_ClearCommand(t *testing.T) {
 	m := newTestModel()
+	client := &mockLLMClient{}
+	m.appState = replappstate.New(client, "")
+	m.appState.AddMessage(llm.RoleUser, "previous")
 	m.textarea.SetValue(replcommands.Clear)
 
 	newM, cmd := m.handleEnterKey()
@@ -219,6 +222,12 @@ func TestHandleEnterKey_ClearCommand(t *testing.T) {
 	}
 	if newM.textarea.Value() != "" {
 		t.Error("expected textarea to be reset")
+	}
+	if len(newM.appState.GetMessages()) != 0 {
+		t.Fatal("expected messages to be cleared")
+	}
+	if client.resetCount != 1 {
+		t.Fatalf("expected LLM client reset once, got %d", client.resetCount)
 	}
 }
 
@@ -256,6 +265,8 @@ func TestStartModelSelection_SetsModelSelection(t *testing.T) {
 
 func TestHandleEnterKey_NewCommand(t *testing.T) {
 	m := newTestModel()
+	client := &mockLLMClient{}
+	m.appState = replappstate.New(client, "")
 	m.textarea.SetValue(replcommands.New)
 
 	newM, cmd := m.handleEnterKey()
@@ -265,6 +276,9 @@ func TestHandleEnterKey_NewCommand(t *testing.T) {
 	}
 	if !strings.Contains(newM.output.Join(), "New session started") {
 		t.Fatalf("expected new session message, got %q", newM.output.Join())
+	}
+	if client.resetCount != 1 {
+		t.Fatalf("expected LLM client reset once, got %d", client.resetCount)
 	}
 }
 

--- a/internal/cli/repl/command_handlers_test.go
+++ b/internal/cli/repl/command_handlers_test.go
@@ -1,15 +1,20 @@
 package repl
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	replappstate "github.com/user/keen-code/internal/cli/repl/appstate"
 	replcommands "github.com/user/keen-code/internal/cli/repl/commands"
 	replwidgets "github.com/user/keen-code/internal/cli/repl/widgets"
 	"github.com/user/keen-code/internal/config"
 	"github.com/user/keen-code/internal/llm"
+	"github.com/user/keen-code/internal/skills"
 	"github.com/user/keen-code/providers"
 )
 
@@ -163,7 +168,7 @@ func TestHandleEnterKey_ClientNotReady(t *testing.T) {
 }
 
 func TestGetHelpText(t *testing.T) {
-	text := getHelpText()
+	text := getHelpText(80)
 
 	if !strings.Contains(text, "/compact") {
 		t.Error("expected /compact in help text")
@@ -183,6 +188,27 @@ func TestGetHelpText(t *testing.T) {
 	if !strings.Contains(text, "/sessions") {
 		t.Error("expected /sessions in help text")
 	}
+	if !strings.Contains(text, "/skills") {
+		t.Error("expected /skills in help text")
+	}
+}
+
+func TestGetHelpTextWrapsCommandDescriptions(t *testing.T) {
+	text := getHelpText(48)
+	stripped := ansi.Strip(text)
+
+	if !strings.Contains(stripped, "  Available Commands") {
+		t.Fatalf("expected padded title, got %q", stripped)
+	}
+	if strings.Contains(stripped, "\n/show-thinking") {
+		t.Fatalf("expected /show-thinking to stay in command column, got %q", stripped)
+	}
+
+	for _, line := range strings.Split(stripped, "\n") {
+		if lipgloss.Width(line) > 46 {
+			t.Fatalf("help line exceeds padded width (%d > %d): %q", lipgloss.Width(line), 46, line)
+		}
+	}
 }
 
 func TestDispatchCommand_UnknownCommandFallsThrough(t *testing.T) {
@@ -192,6 +218,157 @@ func TestDispatchCommand_UnknownCommandFallsThrough(t *testing.T) {
 
 	if handled {
 		t.Error("expected unknown input to not be handled by dispatchCommand")
+	}
+}
+
+func TestHandleSkillsCommandList(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+	m.textarea.SetValue("/skills list")
+	newM, _ := m.handleEnterKey()
+
+	out := newM.output.Join()
+	stripped := ansi.Strip(out)
+	if !strings.Contains(out, "\x1b[1;38;2;189;189;189m  Available Skills") || strings.Contains(stripped, "Available Skills:") {
+		t.Fatalf("expected header-colored skills title without colon, got %q", out)
+	}
+	if !strings.Contains(out, "38;2;92;107;192mdemo") {
+		t.Fatalf("expected primary-colored skill name, got %q", out)
+	}
+	for _, expected := range []string{"Skill", "Status", "Description", "────", "demo", "✓ enabled", "Demo skill"} {
+		if !strings.Contains(stripped, expected) {
+			t.Fatalf("expected %q in skills list output, got %q", expected, stripped)
+		}
+	}
+}
+
+func TestHandleSkillsCommandListStylesDisabledStatus(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	cfg := skills.Config{IsEnabled: map[string]bool{"demo": false}}
+	if err := skills.SaveConfig(cfg); err != nil {
+		t.Fatalf("save skills config: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+	m.textarea.SetValue("/skills list")
+	newM, _ := m.handleEnterKey()
+
+	out := newM.output.Join()
+	if !strings.Contains(out, "38;2;255;179;0m✗ disabled") {
+		t.Fatalf("expected accent-colored disabled status, got %q", out)
+	}
+	if !strings.Contains(ansi.Strip(out), "✗ disabled") {
+		t.Fatalf("expected disabled status in skills list, got %q", out)
+	}
+}
+
+func TestHandleSkillsCommandListWrapsLongDescriptions(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	description := "This skill has a very long description that should wrap within the viewport boundary instead of overflowing horizontally."
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: "+description+"\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+	m.width = 50
+	m.viewport.SetWidth(50)
+	m.output.SetWidth(50)
+	m.textarea.SetValue("/skills list")
+	newM, _ := m.handleEnterKey()
+
+	for _, line := range strings.Split(ansi.Strip(newM.output.Join()), "\n") {
+		if !strings.Contains(line, "demo") && !strings.Contains(line, description[:10]) {
+			continue
+		}
+		if lipgloss.Width(line) > 48 {
+			t.Fatalf("skill line exceeds padded width (%d > %d): %q", lipgloss.Width(line), 48, line)
+		}
+	}
+}
+
+func TestHandleSkillsCommandDisable(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+	m.textarea.SetValue("/skills demo disable")
+	newM, _ := m.handleEnterKey()
+
+	if !strings.Contains(newM.output.Join(), "Skill \"demo\" disabled") {
+		t.Fatalf("expected disable confirmation, got %q", newM.output.Join())
+	}
+	if newM.appState.GetSkillsConfig().Enabled("demo") {
+		t.Fatal("expected appstate config to disable skill")
+	}
+}
+
+func TestHandleSkillsCommandReload(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+
+	writeSkillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(writeSkillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(writeSkillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m.textarea.SetValue("/skills reload")
+	newM, _ := m.handleEnterKey()
+
+	if !strings.Contains(newM.output.Join(), "Skills reloaded") {
+		t.Fatalf("expected reload confirmation, got %q", newM.output.Join())
+	}
+	if _, ok := skills.Find(newM.appState.GetSkills().Skills, "demo"); !ok {
+		t.Fatal("expected reloaded appstate to include new skill")
 	}
 }
 

--- a/internal/cli/repl/commands/commands.go
+++ b/internal/cli/repl/commands/commands.go
@@ -13,6 +13,7 @@ const (
 	Resume       = "/resume"
 	Sessions     = "/sessions"
 	ShowThinking = "/show-thinking"
+	Skills       = "/skills"
 	Thinking     = "/thinking"
 )
 
@@ -32,6 +33,7 @@ var All = []SlashCommand{
 	{Resume, "Open the session picker"},
 	{Sessions, "List saved sessions for this directory"},
 	{ShowThinking, "Toggle thinking token display (on|off)"},
+	{Skills, "List, reload, enable, or disable skills"},
 	{Thinking, "Change thinking effort for the current model"},
 }
 

--- a/internal/cli/repl/handlers.go
+++ b/internal/cli/repl/handlers.go
@@ -429,12 +429,21 @@ func (m *replModel) handleKeyMsg(msg tea.Msg) (replModel, tea.Cmd) {
 	m.textarea, cmd = m.textarea.Update(keyMsg)
 	input := m.textarea.Value()
 	if strings.HasPrefix(input, "/") {
-		m.suggestion.Refresh(input)
+		m.suggestion.RefreshWithSkills(input, m.skillSuggestions())
 	} else {
 		m.refreshFileSuggestions(input)
 	}
 	m.adjustTextareaHeight()
 	return *m, cmd
+}
+
+func (m *replModel) skillSuggestions() []replwidgets.SuggestionItem {
+	skillList := m.appState.SkillSuggestions()
+	items := make([]replwidgets.SuggestionItem, 0, len(skillList))
+	for _, skill := range skillList {
+		items = append(items, replwidgets.SuggestionItem{Name: "/" + skill.Name, Description: skill.Description})
+	}
+	return items
 }
 
 func (m *replModel) refreshFileSuggestions(input string) {

--- a/internal/cli/repl/repl.go
+++ b/internal/cli/repl/repl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/user/keen-code/internal/filesystem"
 	"github.com/user/keen-code/internal/llm"
 	"github.com/user/keen-code/internal/session"
+	"github.com/user/keen-code/internal/skills"
 	"github.com/user/keen-code/providers"
 )
 
@@ -207,6 +208,10 @@ func (m *replModel) handleEnterKey() (replModel, tea.Cmd) {
 		return updated, cmd
 	}
 
+	if activated, ok := m.activateSkillInput(input); ok {
+		input = activated
+	}
+
 	if !m.appState.IsClientReady(m.ctx.cfg) {
 		m.output.AddError("LLM client not initialized. Use /model to configure.", repltheme.ErrorStyle)
 		m.textarea.Reset()
@@ -246,6 +251,26 @@ func (m *replModel) handleEnterKey() (replModel, tea.Cmd) {
 	m.viewport.GotoBottom()
 
 	return *m, tea.Batch(m.spinner.Tick, m.waitForAsyncEvent())
+}
+
+func (m *replModel) activateSkillInput(input string) (string, bool) {
+	if !strings.HasPrefix(input, "/") || strings.Contains(input, "\n") {
+		return "", false
+	}
+	fields := strings.Fields(strings.TrimPrefix(input, "/"))
+	if len(fields) == 0 {
+		return "", false
+	}
+
+	skill, ok := m.appState.FindEnabledSkill(fields[0])
+	if !ok {
+		return "", false
+	}
+	msg, err := skills.ActivationMessage(skill, fields[1:])
+	if err != nil {
+		return "", false
+	}
+	return msg, true
 }
 
 func (m *replModel) updateViewportContent() {

--- a/internal/cli/repl/repl_test.go
+++ b/internal/cli/repl/repl_test.go
@@ -135,7 +135,7 @@ func TestActivateSkillInput(t *testing.T) {
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		t.Fatalf("mkdir skill: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Demo\nDo something useful."), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: demo\ndescription: Demo skill\n---\n# Demo\nargs=$ARGUMENTS"), 0644); err != nil {
 		t.Fatalf("write skill: %v", err)
 	}
 
@@ -146,7 +146,36 @@ func TestActivateSkillInput(t *testing.T) {
 	if !ok {
 		t.Fatal("expected skill activation")
 	}
-	if !strings.Contains(activated, "[Activate skill: demo]") || !strings.Contains(activated, "# Demo") || !strings.Contains(activated, "Arguments: thing") {
+	if !strings.Contains(activated, "[Activate skill: demo]") || !strings.Contains(activated, "# Demo") || !strings.Contains(activated, "args=thing") {
+		t.Fatalf("unexpected activation message: %q", activated)
+	}
+}
+
+func TestActivateSkillInput_UsesFrontmatterNameNotDir(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "any-dir")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: real-name\ndescription: Demo skill\n---\nbody=$ARGUMENTS"), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+
+	if _, ok := m.activateSkillInput("/any-dir foo"); ok {
+		t.Fatal("expected /<dirname> to NOT activate")
+	}
+
+	activated, ok := m.activateSkillInput("/real-name foo")
+	if !ok {
+		t.Fatal("expected /<frontmatter-name> to activate")
+	}
+	if !strings.Contains(activated, "[Activate skill: real-name]") || !strings.Contains(activated, "body=foo") {
 		t.Fatalf("unexpected activation message: %q", activated)
 	}
 }

--- a/internal/cli/repl/repl_test.go
+++ b/internal/cli/repl/repl_test.go
@@ -2,6 +2,8 @@ package repl
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -122,6 +124,30 @@ func TestAdjustTextareaHeight(t *testing.T) {
 	expectedVPHeight := m.height - m.textarea.Height() - 4
 	if m.viewport.Height() != expectedVPHeight {
 		t.Errorf("expected viewport height %d, got %d", expectedVPHeight, m.viewport.Height())
+	}
+}
+
+func TestActivateSkillInput(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	skillDir := filepath.Join(work, ".agents", "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Demo\nDo something useful."), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+
+	m := newTestModel()
+	m.ctx.workingDir = work
+	m.appState = replappstate.New(nil, work)
+	activated, ok := m.activateSkillInput("/demo thing")
+	if !ok {
+		t.Fatal("expected skill activation")
+	}
+	if !strings.Contains(activated, "[Activate skill: demo]") || !strings.Contains(activated, "# Demo") || !strings.Contains(activated, "Arguments: thing") {
+		t.Fatalf("unexpected activation message: %q", activated)
 	}
 }
 

--- a/internal/cli/repl/test_helpers_test.go
+++ b/internal/cli/repl/test_helpers_test.go
@@ -9,6 +9,7 @@ import (
 
 type mockLLMClient struct {
 	streamChatFunc func(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry) (<-chan llm.StreamEvent, error)
+	resetCount     int
 }
 
 func (m *mockLLMClient) StreamChat(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry) (<-chan llm.StreamEvent, error) {
@@ -18,4 +19,8 @@ func (m *mockLLMClient) StreamChat(ctx context.Context, messages []llm.Message, 
 	ch := make(chan llm.StreamEvent)
 	close(ch)
 	return ch, nil
+}
+
+func (m *mockLLMClient) Reset() {
+	m.resetCount++
 }

--- a/internal/cli/repl/widgets/suggestion.go
+++ b/internal/cli/repl/widgets/suggestion.go
@@ -32,13 +32,26 @@ func NewSuggestionModel() SuggestionModel {
 	return SuggestionModel{}
 }
 
-// Refresh filters slash commands matching input and shows them.
 func (s *SuggestionModel) Refresh(input string) {
+	s.RefreshWithSkills(input, nil)
+}
+
+func (s *SuggestionModel) RefreshWithSkills(input string, skills []SuggestionItem) {
 	s.mode = commandMode
 	cmds := replcommands.Filter(input)
-	s.items = make([]SuggestionItem, len(cmds))
-	for i, c := range cmds {
-		s.items[i] = SuggestionItem{Name: c.Name, Description: c.Description}
+	s.items = make([]SuggestionItem, 0, len(cmds)+len(skills))
+	for _, c := range cmds {
+		s.items = append(s.items, SuggestionItem{Name: c.Name, Description: c.Description})
+	}
+	prefix := strings.ToLower(strings.TrimPrefix(input, "/"))
+	for _, skill := range skills {
+		name := strings.TrimPrefix(skill.Name, "/")
+		if strings.HasPrefix(strings.ToLower(name), prefix) {
+			if !strings.HasPrefix(skill.Name, "/") {
+				skill.Name = "/" + skill.Name
+			}
+			s.items = append(s.items, skill)
+		}
 	}
 	if len(s.items) > 0 {
 		s.visible = true

--- a/internal/cli/repl/widgets/suggestion_test.go
+++ b/internal/cli/repl/widgets/suggestion_test.go
@@ -14,10 +14,10 @@ func TestFilterCommandsEmpty(t *testing.T) {
 
 func TestFilterCommandsSlashOnly(t *testing.T) {
 	got := replcommands.Filter("/")
-	if len(got) != 11 {
-		t.Fatalf("expected 11 commands, got %d", len(got))
+	if len(got) != 12 {
+		t.Fatalf("expected 12 commands, got %d", len(got))
 	}
-	if got[0].Name != "/clear" || got[1].Name != "/compact" || got[2].Name != "/exit" || got[3].Name != "/help" || got[4].Name != "/logout" || got[5].Name != "/model" || got[6].Name != "/new" || got[7].Name != "/resume" || got[8].Name != "/sessions" || got[9].Name != "/show-thinking" || got[10].Name != "/thinking" {
+	if got[0].Name != "/clear" || got[1].Name != "/compact" || got[2].Name != "/exit" || got[3].Name != "/help" || got[4].Name != "/logout" || got[5].Name != "/model" || got[6].Name != "/new" || got[7].Name != "/resume" || got[8].Name != "/sessions" || got[9].Name != "/show-thinking" || got[10].Name != "/skills" || got[11].Name != "/thinking" {
 		t.Errorf("unexpected order: %v", got)
 	}
 }
@@ -126,6 +126,17 @@ func TestSuggestionRefreshSlash(t *testing.T) {
 	}
 	if len(s.items) == 0 {
 		t.Error("expected items populated")
+	}
+}
+
+func TestSuggestionRefreshWithSkills(t *testing.T) {
+	s := NewSuggestionModel()
+	s.RefreshWithSkills("/de", []SuggestionItem{{Name: "/deploy", Description: "Deploy app"}})
+	if !s.visible {
+		t.Fatal("expected suggestions visible")
+	}
+	if len(s.items) != 1 || s.items[0].Name != "/deploy" {
+		t.Fatalf("unexpected items: %#v", s.items)
 	}
 }
 

--- a/internal/filesystem/guard.go
+++ b/internal/filesystem/guard.go
@@ -56,6 +56,10 @@ func (g *Guard) CheckPath(path string, operation string) Permission {
 		return PermissionDenied
 	}
 
+	if operation == "read" && g.IsInSkillDir(resolved) {
+		return PermissionGranted
+	}
+
 	inWorkingDir := g.IsInWorkingDir(resolved)
 
 	switch operation {
@@ -79,6 +83,10 @@ func (g *Guard) IsBlocked(path string) bool {
 
 	if g.gitignore != nil && (g.gitignore.IsIgnored(path) || g.gitignore.IsIgnored(resolved)) {
 		return true
+	}
+
+	if g.IsInSkillDir(resolved) {
+		return false
 	}
 
 	home, _ := os.UserHomeDir()
@@ -116,4 +124,26 @@ func (g *Guard) IsInWorkingDir(path string) bool {
 
 	prefix := workingDirClean + string(filepath.Separator)
 	return strings.HasPrefix(cleaned+string(filepath.Separator), prefix)
+}
+
+func (g *Guard) IsInSkillDir(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+
+	cleaned := filepath.Clean(path)
+	for _, dir := range []string{
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".keen", "skills"),
+	} {
+		if cleaned == dir {
+			return true
+		}
+		prefix := dir + string(filepath.Separator)
+		if strings.HasPrefix(cleaned+string(filepath.Separator), prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/filesystem/guard_test.go
+++ b/internal/filesystem/guard_test.go
@@ -56,6 +56,71 @@ func TestGuard_CheckPath_SensitivePath(t *testing.T) {
 	}
 }
 
+func TestGuard_CheckPath_AgentsSkillsDirGrantsReadOutsideWorkingDir(t *testing.T) {
+	home := t.TempDir()
+	workingDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	g := NewGuard(workingDir, nil)
+	skillPath := filepath.Join(home, ".agents", "skills", "demo", "SKILL.md")
+	got := g.CheckPath(skillPath, "read")
+	if got != PermissionGranted {
+		t.Errorf("CheckPath(~/.agents/skills skill, read) = %v, want PermissionGranted", got)
+	}
+}
+
+func TestGuard_CheckPath_AgentsSkillsDirDoesNotGrantWrite(t *testing.T) {
+	home := t.TempDir()
+	workingDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	g := NewGuard(workingDir, nil)
+	skillPath := filepath.Join(home, ".agents", "skills", "demo", "SKILL.md")
+	got := g.CheckPath(skillPath, "write")
+	if got != PermissionPending {
+		t.Errorf("CheckPath(~/.agents/skills skill, write) = %v, want PermissionPending", got)
+	}
+}
+
+func TestGuard_IsBlocked_SkillDirsAllowed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	g := NewGuard(t.TempDir(), nil)
+	for _, skillPath := range []string{
+		filepath.Join(home, ".agents", "skills", "demo", "SKILL.md"),
+		filepath.Join(home, ".keen", "skills", "builtin", "demo", "SKILL.md"),
+	} {
+		if g.IsBlocked(skillPath) {
+			t.Errorf("expected skill path to not be blocked: %s", skillPath)
+		}
+	}
+}
+
+func TestGuard_IsBlocked_AgentsOutsideSkillsDenied(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	g := NewGuard(t.TempDir(), nil)
+	path := filepath.Join(home, ".agents", "config.json")
+	if !g.IsBlocked(path) {
+		t.Error("expected ~/.agents path outside skills to be blocked")
+	}
+}
+
+func TestGuard_CheckPath_KeenSkillsDirGrantsReadOutsideWorkingDir(t *testing.T) {
+	home := t.TempDir()
+	workingDir := t.TempDir()
+	t.Setenv("HOME", home)
+
+	g := NewGuard(workingDir, nil)
+	skillPath := filepath.Join(home, ".keen", "skills", "builtin", "demo", "SKILL.md")
+	got := g.CheckPath(skillPath, "read")
+	if got != PermissionGranted {
+		t.Errorf("CheckPath(~/.keen/skills skill, read) = %v, want PermissionGranted", got)
+	}
+}
+
 func TestGuard_IsBlocked_Gitignore(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitignorePath := filepath.Join(tmpDir, ".gitignore")

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -388,6 +388,10 @@ func (c *AnthropicClient) StreamChat(
 	return eventCh, nil
 }
 
+func (c *AnthropicClient) Reset() {
+	c.pendingState = nil
+}
+
 func (c *AnthropicClient) injectPendingState(msgParams []anthropic.MessageParam) ([]anthropic.MessageParam, []anthropic.MessageParam) {
 	if len(c.pendingState) == 0 {
 		return msgParams, nil

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -8,4 +8,5 @@ import (
 
 type LLMClient interface {
 	StreamChat(ctx context.Context, messages []Message, toolRegistry *tools.Registry) (<-chan StreamEvent, error)
+	Reset()
 }

--- a/internal/llm/genkit.go
+++ b/internal/llm/genkit.go
@@ -256,6 +256,10 @@ func (c *GenkitClient) StreamChat(
 	return eventCh, nil
 }
 
+func (c *GenkitClient) Reset() {
+	c.pendingState = nil
+}
+
 func (c *GenkitClient) injectPendingState(aiMessages []*ai.Message) ([]*ai.Message, []*ai.Message) {
 	if len(c.pendingState) == 0 {
 		return aiMessages, nil

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -466,6 +466,10 @@ func (c *OpenAICompatibleClient) StreamChat(
 	return eventCh, nil
 }
 
+func (c *OpenAICompatibleClient) Reset() {
+	c.pendingState = nil
+}
+
 func (c *OpenAICompatibleClient) savePendingIfAccumulated(oaiMessages []openai.ChatCompletionMessageParamUnion, turnStartLen int, injectedPending []openai.ChatCompletionMessageParamUnion) {
 	if len(injectedPending) == 0 && len(oaiMessages) <= turnStartLen {
 		return

--- a/internal/llm/openai_codex.go
+++ b/internal/llm/openai_codex.go
@@ -136,6 +136,10 @@ func (c *OpenAICodexClient) StreamChat(ctx context.Context, messages []Message, 
 	return eventCh, nil
 }
 
+func (c *OpenAICodexClient) Reset() {
+	c.pendingState = nil
+}
+
 func codexInstructionsAndInput(messages []Message) (string, []responses.ResponseInputItemUnionParam) {
 	instructions := make([]string, 0, 1)
 	inputMessages := make([]Message, 0, len(messages))

--- a/internal/llm/openai_responses.go
+++ b/internal/llm/openai_responses.go
@@ -211,6 +211,10 @@ func (c *OpenAIResponsesClient) StreamChat(
 	return eventCh, nil
 }
 
+func (c *OpenAIResponsesClient) Reset() {
+	c.pendingState = nil
+}
+
 func (c *OpenAIResponsesClient) injectPendingState(input []responses.ResponseInputItemUnionParam) ([]responses.ResponseInputItemUnionParam, []responses.ResponseInputItemUnionParam) {
 	if len(c.pendingState) == 0 {
 		return input, nil

--- a/internal/llm/systemprompt.go
+++ b/internal/llm/systemprompt.go
@@ -93,7 +93,7 @@ A structured list of files that are still important to continue the task.`
 
 const maxInstructionsSize = 8 * 1024
 
-func Build(workingDir string) string {
+func Build(workingDir, skillsCatalog string) string {
 	var sb strings.Builder
 	sb.WriteString(staticPrompt)
 	sb.WriteString(fmt.Sprintf("\n\nWorking directory: %s", workingDir))
@@ -102,6 +102,11 @@ func Build(workingDir string) string {
 	if instructions != "" {
 		sb.WriteString("\n\n")
 		sb.WriteString(instructions)
+	}
+
+	if skillsCatalog != "" {
+		sb.WriteString("\n\n")
+		sb.WriteString(skillsCatalog)
 	}
 
 	return sb.String()

--- a/internal/llm/systemprompt.go
+++ b/internal/llm/systemprompt.go
@@ -19,7 +19,7 @@ refactoring code, explaining code, exploring codebases, writing tests, and more.
 - Do not preemptively explain what you are going to do. Explain if users asks for it.
 - Be very concise in your responses. Explanation should not be verbose. Let user ask for
   more details.
-- After finishing a turn, add a brief summary of what you did only if it is strictly useful.
+- After finishing a turn, add a brief summary of what you did for your own reference.
 - One-word or one-line answers are fine when that is all the question needs.
 - Never use bash or code comments as a communication channel — write to the
   user in your response text only.
@@ -55,7 +55,8 @@ refactoring code, explaining code, exploring codebases, writing tests, and more.
 - Raw tool calls and their outputs are only retained within the current turn. 
 - At the end of a turn, a "Tool memory" block may be created that notes down the
   written/edited files and failed bash commands.
-- Use the tool memory to retain some ideas on past tool usages for future turns.
+- Since tool outputs are not retained after a turn finishes, prefer writing a brief summary
+  of what you did in that turn for your own reference.
 - For other tools (read_file, grep, glob), run them again if needed without side-effects.
 
 # Git rules

--- a/internal/llm/systemprompt_test.go
+++ b/internal/llm/systemprompt_test.go
@@ -5,11 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/user/keen-code/internal/skills"
 )
 
 func TestBuild_ContainsIdentity(t *testing.T) {
 	dir := t.TempDir()
-	result := Build(dir)
+	result := Build(dir, "")
 	if !strings.Contains(result, "Keen Code") {
 		t.Error("expected output to contain 'Keen Code'")
 	}
@@ -17,7 +19,7 @@ func TestBuild_ContainsIdentity(t *testing.T) {
 
 func TestBuild_ContainsWorkingDir(t *testing.T) {
 	dir := t.TempDir()
-	result := Build(dir)
+	result := Build(dir, "")
 	if !strings.Contains(result, dir) {
 		t.Errorf("expected output to contain working dir %q", dir)
 	}
@@ -28,7 +30,7 @@ func TestBuild_AgentsMd_Found(t *testing.T) {
 	content := "## My Project\nSome instructions here."
 	os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(content), 0644)
 
-	result := Build(dir)
+	result := Build(dir, "")
 	if !strings.Contains(result, "# Project Instructions") {
 		t.Error("expected project instructions section")
 	}
@@ -43,7 +45,7 @@ func TestBuild_AgentsMd_WalkUp(t *testing.T) {
 	os.MkdirAll(child, 0755)
 	os.WriteFile(filepath.Join(parent, "AGENTS.md"), []byte("parent instructions"), 0644)
 
-	result := Build(child)
+	result := Build(child, "")
 	if !strings.Contains(result, "parent instructions") {
 		t.Error("expected AGENTS.md from parent directory")
 	}
@@ -53,7 +55,7 @@ func TestBuild_ClaudeMd_Fallback(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("claude instructions"), 0644)
 
-	result := Build(dir)
+	result := Build(dir, "")
 	if !strings.Contains(result, "claude instructions") {
 		t.Error("expected CLAUDE.md content as fallback")
 	}
@@ -61,7 +63,7 @@ func TestBuild_ClaudeMd_Fallback(t *testing.T) {
 
 func TestBuild_NoInstructionFile(t *testing.T) {
 	dir := t.TempDir()
-	result := Build(dir)
+	result := Build(dir, "")
 	if strings.Contains(result, "# Project Instructions") {
 		t.Error("expected no project instructions section when no file exists")
 	}
@@ -72,7 +74,7 @@ func TestBuild_AgentsMd_Truncation(t *testing.T) {
 	content := strings.Repeat("x", 10*1024)
 	os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(content), 0644)
 
-	result := Build(dir)
+	result := Build(dir, "")
 	if !strings.Contains(result, "[truncated") {
 		t.Error("expected truncation note for large AGENTS.md")
 	}
@@ -82,7 +84,7 @@ func TestBuild_AgentsMd_Empty(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(""), 0644)
 
-	result := Build(dir)
+	result := Build(dir, "")
 	if strings.Contains(result, "# Project Instructions") {
 		t.Error("expected no project instructions for empty AGENTS.md")
 	}
@@ -90,9 +92,22 @@ func TestBuild_AgentsMd_Empty(t *testing.T) {
 
 func TestBuild_FreshOnEachCall(t *testing.T) {
 	dir := t.TempDir()
-	result1 := Build(dir)
-	result2 := Build(dir)
+	result1 := Build(dir, "")
+	result2 := Build(dir, "")
 	if result1 != result2 {
 		t.Error("expected identical output from two Build calls with same args")
+	}
+}
+
+func TestBuild_IncludesSkillsCatalog(t *testing.T) {
+	dir := t.TempDir()
+	catalog := skills.Catalog([]skills.Skill{{Name: "demo", Description: "Demo skill", Location: "/tmp/demo/SKILL.md"}}, skills.Config{})
+
+	result := Build(dir, catalog)
+	if !strings.Contains(result, "## Available Skills") {
+		t.Fatal("expected skills catalog")
+	}
+	if !strings.Contains(result, "- demo: Demo skill") {
+		t.Fatalf("expected demo skill in catalog, got %q", result)
 	}
 }

--- a/internal/skills/config.go
+++ b/internal/skills/config.go
@@ -1,0 +1,75 @@
+package skills
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	IsEnabled map[string]bool `json:"is_enabled"`
+}
+
+func LoadConfig() Config {
+	path, err := ConfigPath()
+	if err != nil {
+		return Config{IsEnabled: map[string]bool{}}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{IsEnabled: map[string]bool{}}
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Config{IsEnabled: map[string]bool{}}
+	}
+	if cfg.IsEnabled == nil {
+		cfg.IsEnabled = map[string]bool{}
+	}
+	return cfg
+}
+
+func SaveConfig(cfg Config) error {
+	path, err := ConfigPath()
+	if err != nil {
+		return err
+	}
+	if cfg.IsEnabled == nil {
+		cfg.IsEnabled = map[string]bool{}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0644)
+}
+
+func ConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".keen", "skills", "config.json"), nil
+}
+
+func (c Config) Enabled(name string) bool {
+	if c.IsEnabled == nil {
+		return true
+	}
+	enabled, ok := c.IsEnabled[name]
+	if !ok {
+		return true
+	}
+	return enabled
+}
+
+func (c *Config) SetEnabled(name string, enabled bool) {
+	if c.IsEnabled == nil {
+		c.IsEnabled = map[string]bool{}
+	}
+	c.IsEnabled[name] = enabled
+}

--- a/internal/skills/config_test.go
+++ b/internal/skills/config_test.go
@@ -1,0 +1,49 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigEnabledDefaultsTrue(t *testing.T) {
+	if !((Config{}).Enabled("demo")) {
+		t.Fatal("expected missing config to default enabled")
+	}
+	cfg := Config{IsEnabled: map[string]bool{"demo": false}}
+	if cfg.Enabled("demo") {
+		t.Fatal("expected disabled skill")
+	}
+}
+
+func TestConfigSetEnabled(t *testing.T) {
+	var cfg Config
+	cfg.SetEnabled("demo", false)
+	if cfg.Enabled("demo") {
+		t.Fatal("expected skill disabled")
+	}
+}
+
+func TestLoadSaveConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := Config{IsEnabled: map[string]bool{"demo": false}}
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig() error = %v", err)
+	}
+	loaded := LoadConfig()
+	if loaded.Enabled("demo") {
+		t.Fatal("expected saved disabled state")
+	}
+	if _, err := os.Stat(filepath.Join(home, ".keen", "skills", "config.json")); err != nil {
+		t.Fatalf("expected config file: %v", err)
+	}
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cfg := LoadConfig()
+	if !cfg.Enabled("demo") {
+		t.Fatal("expected default enabled")
+	}
+}

--- a/internal/skills/discover.go
+++ b/internal/skills/discover.go
@@ -108,6 +108,8 @@ containing SKILL.md:
 		sb.WriteString(skill.Location)
 		sb.WriteString("\n")
 	}
+	sb.WriteString(`IMPORTANT: If users invoke a skill by "/<skill-name>" commands, the instructions are
+already in your conversation context. So do not read the skill's SKILL.md file again.`)
 	return strings.TrimRight(sb.String(), "\n")
 }
 

--- a/internal/skills/discover.go
+++ b/internal/skills/discover.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -15,7 +16,7 @@ type Discovery struct {
 
 func Discover(workingDir string) Discovery {
 	var result Discovery
-	loaded := map[string]Skill{}
+	seen := map[string]bool{}
 
 	for _, root := range discoveryRoots(workingDir) {
 		matches, err := filepath.Glob(filepath.Join(root, "*", "SKILL.md"))
@@ -24,50 +25,48 @@ func Discover(workingDir string) Discovery {
 		}
 		sort.Strings(matches)
 		for _, skillPath := range matches {
-			name := filepath.Base(filepath.Dir(skillPath))
-			if _, exists := loaded[name]; exists {
+			dirName := filepath.Base(filepath.Dir(skillPath))
+			if seen[dirName] {
 				continue
 			}
+			seen[dirName] = true
 
 			absPath, err := filepath.Abs(skillPath)
 			if err != nil {
 				continue
 			}
-			loaded[name] = Skill{
-				Name:        name,
-				Description: name,
+			result.Skills = append(result.Skills, Skill{
+				Name:        dirName,
+				Description: dirName,
 				Location:    absPath,
-			}
+			})
 		}
 	}
 
-	for _, skill := range loaded {
-		result.Skills = append(result.Skills, skill)
-	}
-	sort.Slice(result.Skills, func(i, j int) bool {
-		return result.Skills[i].Name < result.Skills[j].Name
-	})
 	return result
 }
 
 func LoadMetadata(discovery Discovery) Discovery {
 	result := Discovery{Warnings: append([]string(nil), discovery.Warnings...)}
 	result.Skills = make([]Skill, 0, len(discovery.Skills))
+	byName := map[string]string{}
 
 	for _, discovered := range discovery.Skills {
 		data, err := os.ReadFile(discovered.Location)
 		if err != nil {
-			result.Skills = append(result.Skills, discovered)
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Skill %s failed to load: %v", discovered.Name, err))
 			continue
 		}
-		skill, ok, err := ParseSkillMetadata(discovered.Location, discovered.Name, data)
+		skill, err := ParseSkillMetadata(discovered.Location, data)
 		if err != nil {
-			result.Warnings = append(result.Warnings, "Skill "+discovered.Name+" failed to load due to YAML parsing issue")
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Skill %s failed to load: %v", discovered.Name, err))
 			continue
 		}
-		if !ok {
+		if existing, dup := byName[skill.Name]; dup {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("Skill %s skipped: name %q already used by %s", discovered.Name, skill.Name, existing))
 			continue
 		}
+		byName[skill.Name] = discovered.Name
 		result.Skills = append(result.Skills, skill)
 	}
 
@@ -108,8 +107,9 @@ containing SKILL.md:
 		sb.WriteString(skill.Location)
 		sb.WriteString("\n")
 	}
-	sb.WriteString(`IMPORTANT: If users invoke a skill by "/<skill-name>" commands, the instructions are
-already in your conversation context. So do not read the skill's SKILL.md file again.`)
+	sb.WriteString("IMPORTANT: If any user message in this conversation begins with " +
+		"`[Activate skill: <name>]`, the SKILL.md body for that skill has already been " +
+		"provided inline in that message — do not call read_file on its path.")
 	return strings.TrimRight(sb.String(), "\n")
 }
 
@@ -139,15 +139,27 @@ func ActivationMessage(skill Skill, args []string) (string, error) {
 		return "", fmt.Errorf("read skill %s: %w", skill.Name, err)
 	}
 
+	body := substituteArgs(strings.TrimSpace(string(content)), args)
+
 	var sb strings.Builder
 	sb.WriteString("[Activate skill: ")
 	sb.WriteString(skill.Name)
-	sb.WriteString("]")
-	if len(args) > 0 {
-		sb.WriteString("\nArguments: ")
-		sb.WriteString(strings.Join(args, " "))
-	}
-	sb.WriteString("\n\n")
-	sb.WriteString(strings.TrimSpace(string(content)))
+	sb.WriteString("]\n\n")
+	sb.WriteString(body)
 	return sb.String(), nil
+}
+
+var argPlaceholder = regexp.MustCompile(`\$ARGUMENTS\b|\$([1-9])\b`)
+
+func substituteArgs(body string, args []string) string {
+	return argPlaceholder.ReplaceAllStringFunc(body, func(match string) string {
+		if match == "$ARGUMENTS" {
+			return strings.Join(args, " ")
+		}
+		idx := int(match[1]-'0') - 1
+		if idx < len(args) {
+			return args[idx]
+		}
+		return ""
+	})
 }

--- a/internal/skills/discover.go
+++ b/internal/skills/discover.go
@@ -1,0 +1,151 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Discovery struct {
+	Skills   []Skill
+	Warnings []string
+}
+
+func Discover(workingDir string) Discovery {
+	var result Discovery
+	loaded := map[string]Skill{}
+
+	for _, root := range discoveryRoots(workingDir) {
+		matches, err := filepath.Glob(filepath.Join(root, "*", "SKILL.md"))
+		if err != nil {
+			continue
+		}
+		sort.Strings(matches)
+		for _, skillPath := range matches {
+			name := filepath.Base(filepath.Dir(skillPath))
+			if _, exists := loaded[name]; exists {
+				continue
+			}
+
+			absPath, err := filepath.Abs(skillPath)
+			if err != nil {
+				continue
+			}
+			loaded[name] = Skill{
+				Name:        name,
+				Description: name,
+				Location:    absPath,
+			}
+		}
+	}
+
+	for _, skill := range loaded {
+		result.Skills = append(result.Skills, skill)
+	}
+	sort.Slice(result.Skills, func(i, j int) bool {
+		return result.Skills[i].Name < result.Skills[j].Name
+	})
+	return result
+}
+
+func LoadMetadata(discovery Discovery) Discovery {
+	result := Discovery{Warnings: append([]string(nil), discovery.Warnings...)}
+	result.Skills = make([]Skill, 0, len(discovery.Skills))
+
+	for _, discovered := range discovery.Skills {
+		data, err := os.ReadFile(discovered.Location)
+		if err != nil {
+			result.Skills = append(result.Skills, discovered)
+			continue
+		}
+		skill, ok, err := ParseSkillMetadata(discovered.Location, discovered.Name, data)
+		if err != nil {
+			result.Warnings = append(result.Warnings, "Skill "+discovered.Name+" failed to load due to YAML parsing issue")
+			continue
+		}
+		if !ok {
+			continue
+		}
+		result.Skills = append(result.Skills, skill)
+	}
+
+	sort.Slice(result.Skills, func(i, j int) bool {
+		return result.Skills[i].Name < result.Skills[j].Name
+	})
+	return result
+}
+
+func Catalog(all []Skill, cfg Config) string {
+	enabled := make([]Skill, 0, len(all))
+	for _, skill := range all {
+		if cfg.Enabled(skill.Name) {
+			enabled = append(enabled, skill)
+		}
+	}
+	if len(enabled) == 0 {
+		return ""
+	}
+
+	sort.Slice(enabled, func(i, j int) bool {
+		return enabled[i].Name < enabled[j].Name
+	})
+
+	var sb strings.Builder
+	sb.WriteString("## Available Skills\n\n")
+	sb.WriteString(`You have access to specialized skills. To activate a skill, use the read_file tool
+to read the skill's SKILL.md file at one of these paths, then follow the instructions
+within. Resolve relative paths in skill instructions against the skill directory
+containing SKILL.md:
+`)
+	for _, skill := range enabled {
+		sb.WriteString("- ")
+		sb.WriteString(skill.Name)
+		sb.WriteString(": ")
+		sb.WriteString(skill.Description)
+		sb.WriteString(" → read ")
+		sb.WriteString(skill.Location)
+		sb.WriteString("\n")
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func discoveryRoots(workingDir string) []string {
+	roots := []string{filepath.Join(workingDir, ".agents", "skills")}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		roots = append(roots,
+			filepath.Join(home, ".agents", "skills"),
+			filepath.Join(home, ".keen", "skills"),
+		)
+	}
+	return roots
+}
+
+func Find(skills []Skill, name string) (Skill, bool) {
+	for _, skill := range skills {
+		if skill.Name == name {
+			return skill, true
+		}
+	}
+	return Skill{}, false
+}
+
+func ActivationMessage(skill Skill, args []string) (string, error) {
+	content, err := os.ReadFile(skill.Location)
+	if err != nil {
+		return "", fmt.Errorf("read skill %s: %w", skill.Name, err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("[Activate skill: ")
+	sb.WriteString(skill.Name)
+	sb.WriteString("]")
+	if len(args) > 0 {
+		sb.WriteString("\nArguments: ")
+		sb.WriteString(strings.Join(args, " "))
+	}
+	sb.WriteString("\n\n")
+	sb.WriteString(strings.TrimSpace(string(content)))
+	return sb.String(), nil
+}

--- a/internal/skills/discover_test.go
+++ b/internal/skills/discover_test.go
@@ -37,10 +37,10 @@ func TestDiscover_ProjectGlobalAndKeenSkills(t *testing.T) {
 	if len(result.Skills) != 3 {
 		t.Fatalf("expected 3 skills, got %d", len(result.Skills))
 	}
-	if result.Skills[0].Name != "builtin" || result.Skills[1].Name != "global" || result.Skills[2].Name != "project" {
-		t.Fatalf("unexpected skills: %#v", result.Skills)
+	if result.Skills[0].Name != "project" || result.Skills[1].Name != "global" || result.Skills[2].Name != "builtin" {
+		t.Fatalf("expected discovery order project/global/builtin, got %#v", result.Skills)
 	}
-	if result.Skills[0].Description != "builtin" || result.Skills[1].Description != "global" || result.Skills[2].Description != "project" {
+	if result.Skills[0].Description != "project" || result.Skills[1].Description != "global" || result.Skills[2].Description != "builtin" {
 		t.Fatalf("expected discovery to avoid reading metadata, got %#v", result.Skills)
 	}
 }
@@ -87,7 +87,7 @@ func TestLoadMetadata_InvalidYAMLWarnsAndSkips(t *testing.T) {
 	if len(result.Skills) != 0 {
 		t.Fatalf("expected no skills, got %#v", result.Skills)
 	}
-	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "Skill bad failed to load due to YAML parsing issue") {
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "Skill bad failed to load") {
 		t.Fatalf("unexpected warnings: %#v", result.Warnings)
 	}
 }
@@ -106,6 +106,36 @@ func TestLoadMetadata_ReadsNameAndDescription(t *testing.T) {
 	}
 }
 
+func TestLoadMetadata_FrontmatterNameOverridesDirName(t *testing.T) {
+	work := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeSkill(t, work, "any-dir", "---\nname: real-name\ndescription: Demo skill\n---\nBody")
+
+	result := LoadMetadata(Discover(work))
+	if len(result.Skills) != 1 || result.Skills[0].Name != "real-name" {
+		t.Fatalf("expected frontmatter name to win, got %#v", result.Skills)
+	}
+}
+
+func TestLoadMetadata_DuplicateFrontmatterNameWarns(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSkill(t, work, "project-dir", "---\nname: shared\ndescription: From project\n---\nBody")
+	writeSkill(t, home, "global-dir", "---\nname: shared\ndescription: From global\n---\nBody")
+
+	result := LoadMetadata(Discover(work))
+	if len(result.Skills) != 1 {
+		t.Fatalf("expected 1 skill after dedup, got %#v", result.Skills)
+	}
+	if result.Skills[0].Description != "From project" {
+		t.Fatalf("expected project to win fm.Name collision, got %#v", result.Skills[0])
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "name \"shared\" already used") {
+		t.Fatalf("expected collision warning, got %#v", result.Warnings)
+	}
+}
+
 func TestCatalog_Empty(t *testing.T) {
 	if got := Catalog(nil, Config{}); got != "" {
 		t.Fatalf("expected empty catalog, got %q", got)
@@ -119,6 +149,9 @@ func TestCatalog_IncludesEnabledSkills(t *testing.T) {
 	}
 	if !strings.Contains(got, "- demo: Demo skill → read /tmp/demo/SKILL.md") {
 		t.Fatalf("expected skill entry, got %q", got)
+	}
+	if !strings.Contains(got, "[Activate skill: <name>]") {
+		t.Fatalf("expected catalog to reference activation marker, got %q", got)
 	}
 }
 
@@ -151,16 +184,16 @@ func writeSkillFile(t *testing.T, content string) Skill {
 }
 
 func TestActivationMessage(t *testing.T) {
-	skill := writeSkillFile(t, "# Demo\nDo something useful.")
-	got, err := ActivationMessage(skill, []string{"foo"})
+	skill := writeSkillFile(t, "# Demo\nargs=$ARGUMENTS")
+	got, err := ActivationMessage(skill, []string{"foo", "bar"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(got, "[Activate skill: demo]") {
 		t.Fatalf("expected activation header, got %q", got)
 	}
-	if !strings.Contains(got, "Arguments: foo") {
-		t.Fatalf("expected arguments, got %q", got)
+	if !strings.Contains(got, "args=foo bar") {
+		t.Fatalf("expected $ARGUMENTS substitution, got %q", got)
 	}
 	if !strings.Contains(got, "# Demo") {
 		t.Fatalf("expected skill content, got %q", got)
@@ -168,13 +201,35 @@ func TestActivationMessage(t *testing.T) {
 }
 
 func TestActivationMessageNoArgs(t *testing.T) {
-	skill := writeSkillFile(t, "# Demo\nDo something useful.")
+	skill := writeSkillFile(t, "# Demo\nargs=$ARGUMENTS done")
 	got, err := ActivationMessage(skill, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Contains(got, "Arguments:") {
-		t.Fatalf("expected no arguments line, got %q", got)
+	if !strings.Contains(got, "args= done") {
+		t.Fatalf("expected $ARGUMENTS to substitute to empty, got %q", got)
+	}
+}
+
+func TestActivationMessagePositional(t *testing.T) {
+	skill := writeSkillFile(t, "first=$1 second=$2 third=$3")
+	got, err := ActivationMessage(skill, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "first=a second=b third=") {
+		t.Fatalf("expected positional substitution with empty fallback, got %q", got)
+	}
+}
+
+func TestActivationMessagePreservesDollarTen(t *testing.T) {
+	skill := writeSkillFile(t, "literal=$10")
+	got, err := ActivationMessage(skill, []string{"a"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "literal=$10") {
+		t.Fatalf("expected $10 untouched, got %q", got)
 	}
 }
 

--- a/internal/skills/discover_test.go
+++ b/internal/skills/discover_test.go
@@ -1,0 +1,187 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeSkill(t *testing.T, root, name, content string) string {
+	t.Helper()
+	return writeSkillAt(t, filepath.Join(root, ".agents", "skills"), name, content)
+}
+
+func writeSkillAt(t *testing.T, skillsDir, name, content string) string {
+	t.Helper()
+	dir := filepath.Join(skillsDir, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+	return path
+}
+
+func TestDiscover_ProjectGlobalAndKeenSkills(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSkill(t, work, "project", "---\nname: project\ndescription: Project skill\n---\nBody")
+	writeSkill(t, home, "global", "---\nname: global\ndescription: Global skill\n---\nBody")
+	writeSkillAt(t, filepath.Join(home, ".keen", "skills"), "builtin", "---\nname: builtin\ndescription: Builtin skill\n---\nBody")
+
+	result := Discover(work)
+	if len(result.Skills) != 3 {
+		t.Fatalf("expected 3 skills, got %d", len(result.Skills))
+	}
+	if result.Skills[0].Name != "builtin" || result.Skills[1].Name != "global" || result.Skills[2].Name != "project" {
+		t.Fatalf("unexpected skills: %#v", result.Skills)
+	}
+	if result.Skills[0].Description != "builtin" || result.Skills[1].Description != "global" || result.Skills[2].Description != "project" {
+		t.Fatalf("expected discovery to avoid reading metadata, got %#v", result.Skills)
+	}
+}
+
+func TestDiscover_ProjectWinsCollision(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSkillAt(t, filepath.Join(home, ".keen", "skills"), "same", "---\nname: same\ndescription: Builtin\n---\nBody")
+	writeSkill(t, home, "same", "---\nname: same\ndescription: Global\n---\nBody")
+	projectPath := writeSkill(t, work, "same", "---\nname: same\ndescription: Project\n---\nBody")
+
+	result := Discover(work)
+	if len(result.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result.Skills))
+	}
+	if result.Skills[0].Location != projectPath {
+		t.Fatalf("expected project skill to win, got %#v", result.Skills[0])
+	}
+}
+
+func TestDiscover_GlobalWinsKeenCollision(t *testing.T) {
+	home := t.TempDir()
+	work := t.TempDir()
+	t.Setenv("HOME", home)
+	writeSkillAt(t, filepath.Join(home, ".keen", "skills"), "same", "---\nname: same\ndescription: Builtin\n---\nBody")
+	globalPath := writeSkill(t, home, "same", "---\nname: same\ndescription: Global\n---\nBody")
+
+	result := Discover(work)
+	if len(result.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result.Skills))
+	}
+	if result.Skills[0].Location != globalPath {
+		t.Fatalf("expected global skill to win, got %#v", result.Skills[0])
+	}
+}
+
+func TestLoadMetadata_InvalidYAMLWarnsAndSkips(t *testing.T) {
+	work := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeSkill(t, work, "bad", "---\nname: [\n---\nBody")
+
+	result := LoadMetadata(Discover(work))
+	if len(result.Skills) != 0 {
+		t.Fatalf("expected no skills, got %#v", result.Skills)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "Skill bad failed to load due to YAML parsing issue") {
+		t.Fatalf("unexpected warnings: %#v", result.Warnings)
+	}
+}
+
+func TestLoadMetadata_ReadsNameAndDescription(t *testing.T) {
+	work := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	writeSkill(t, work, "demo", "---\nname: demo\ndescription: Demo skill\n---\nBody")
+
+	result := LoadMetadata(Discover(work))
+	if len(result.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(result.Skills))
+	}
+	if result.Skills[0].Description != "Demo skill" {
+		t.Fatalf("expected metadata description, got %#v", result.Skills[0])
+	}
+}
+
+func TestCatalog_Empty(t *testing.T) {
+	if got := Catalog(nil, Config{}); got != "" {
+		t.Fatalf("expected empty catalog, got %q", got)
+	}
+}
+
+func TestCatalog_IncludesEnabledSkills(t *testing.T) {
+	got := Catalog([]Skill{{Name: "demo", Description: "Demo skill", Location: "/tmp/demo/SKILL.md"}}, Config{})
+	if !strings.Contains(got, "## Available Skills") {
+		t.Fatalf("expected skills heading, got %q", got)
+	}
+	if !strings.Contains(got, "- demo: Demo skill → read /tmp/demo/SKILL.md") {
+		t.Fatalf("expected skill entry, got %q", got)
+	}
+}
+
+func TestCatalog_ExcludesDisabledSkills(t *testing.T) {
+	cfg := Config{IsEnabled: map[string]bool{"demo": false}}
+	got := Catalog([]Skill{{Name: "demo", Description: "Demo skill", Location: "/tmp/demo/SKILL.md"}}, cfg)
+	if got != "" {
+		t.Fatalf("expected empty catalog for disabled skill, got %q", got)
+	}
+}
+
+func TestFind(t *testing.T) {
+	skill, ok := Find([]Skill{{Name: "one"}}, "one")
+	if !ok || skill.Name != "one" {
+		t.Fatalf("expected to find skill")
+	}
+	if _, ok := Find([]Skill{{Name: "one"}}, "two"); ok {
+		t.Fatalf("expected missing skill")
+	}
+}
+
+func writeSkillFile(t *testing.T, content string) Skill {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SKILL.md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write skill file: %v", err)
+	}
+	return Skill{Name: "demo", Location: path}
+}
+
+func TestActivationMessage(t *testing.T) {
+	skill := writeSkillFile(t, "# Demo\nDo something useful.")
+	got, err := ActivationMessage(skill, []string{"foo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "[Activate skill: demo]") {
+		t.Fatalf("expected activation header, got %q", got)
+	}
+	if !strings.Contains(got, "Arguments: foo") {
+		t.Fatalf("expected arguments, got %q", got)
+	}
+	if !strings.Contains(got, "# Demo") {
+		t.Fatalf("expected skill content, got %q", got)
+	}
+}
+
+func TestActivationMessageNoArgs(t *testing.T) {
+	skill := writeSkillFile(t, "# Demo\nDo something useful.")
+	got, err := ActivationMessage(skill, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "Arguments:") {
+		t.Fatalf("expected no arguments line, got %q", got)
+	}
+}
+
+func TestActivationMessageMissingFile(t *testing.T) {
+	skill := Skill{Name: "demo", Location: "/nonexistent/SKILL.md"}
+	_, err := ActivationMessage(skill, nil)
+	if err == nil {
+		t.Fatal("expected error for missing skill file")
+	}
+}

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -19,41 +19,45 @@ type frontmatter struct {
 	Description string `yaml:"description"`
 }
 
-func ParseSkillMetadata(path, dirName string, data []byte) (Skill, bool, error) {
+func ParseSkillMetadata(path string, data []byte) (Skill, error) {
 	content := string(data)
 	if strings.TrimSpace(content) == "" {
-		return Skill{}, false, nil
-	}
-
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return Skill{}, false, err
-	}
-	skill := Skill{
-		Name:        dirName,
-		Description: dirName,
-		Location:    absPath,
+		return Skill{}, fmt.Errorf("empty SKILL.md")
 	}
 
 	fmText, _, hasFrontmatter, err := splitFrontmatter(content)
 	if err != nil {
-		return Skill{}, false, err
+		return Skill{}, err
 	}
 	if !hasFrontmatter {
-		return skill, true, nil
+		return Skill{}, fmt.Errorf("missing YAML frontmatter")
 	}
 
 	var fm frontmatter
 	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
-		return Skill{}, false, fmt.Errorf("parse frontmatter: %w", err)
+		return Skill{}, fmt.Errorf("parse frontmatter: %w", err)
 	}
-	if strings.TrimSpace(fm.Name) != "" && strings.TrimSpace(fm.Name) == dirName {
-		skill.Name = strings.TrimSpace(fm.Name)
+
+	name := strings.TrimSpace(fm.Name)
+	if name == "" {
+		return Skill{}, fmt.Errorf("missing required frontmatter field: name")
 	}
-	if strings.TrimSpace(fm.Description) != "" {
-		skill.Description = strings.TrimSpace(fm.Description)
+
+	description := strings.TrimSpace(fm.Description)
+	if description == "" {
+		return Skill{}, fmt.Errorf("missing required frontmatter field: description")
 	}
-	return skill, true, nil
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return Skill{}, err
+	}
+
+	return Skill{
+		Name:        name,
+		Description: description,
+		Location:    absPath,
+	}, nil
 }
 
 func splitFrontmatter(content string) (string, string, bool, error) {

--- a/internal/skills/parse.go
+++ b/internal/skills/parse.go
@@ -1,0 +1,72 @@
+package skills
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Skill struct {
+	Name        string
+	Description string
+	Location    string
+}
+
+type frontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+func ParseSkillMetadata(path, dirName string, data []byte) (Skill, bool, error) {
+	content := string(data)
+	if strings.TrimSpace(content) == "" {
+		return Skill{}, false, nil
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return Skill{}, false, err
+	}
+	skill := Skill{
+		Name:        dirName,
+		Description: dirName,
+		Location:    absPath,
+	}
+
+	fmText, _, hasFrontmatter, err := splitFrontmatter(content)
+	if err != nil {
+		return Skill{}, false, err
+	}
+	if !hasFrontmatter {
+		return skill, true, nil
+	}
+
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return Skill{}, false, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	if strings.TrimSpace(fm.Name) != "" && strings.TrimSpace(fm.Name) == dirName {
+		skill.Name = strings.TrimSpace(fm.Name)
+	}
+	if strings.TrimSpace(fm.Description) != "" {
+		skill.Description = strings.TrimSpace(fm.Description)
+	}
+	return skill, true, nil
+}
+
+func splitFrontmatter(content string) (string, string, bool, error) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(strings.TrimSuffix(lines[0], "\r")) != "---" {
+		return "", "", false, nil
+	}
+
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(strings.TrimSuffix(lines[i], "\r")) == "---" {
+			return strings.Join(lines[1:i], "\n"), strings.Join(lines[i+1:], "\n"), true, nil
+		}
+	}
+
+	return "", "", false, fmt.Errorf("missing closing frontmatter delimiter")
+}

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -1,0 +1,61 @@
+package skills
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSkillMetadata_WithFrontmatter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "demo", "SKILL.md")
+	skill, ok, err := ParseSkillMetadata(path, "demo", []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected skill to load")
+	}
+	if skill.Name != "demo" || skill.Description != "Demo skill" {
+		t.Fatalf("unexpected skill: %#v", skill)
+	}
+	if !filepath.IsAbs(skill.Location) {
+		t.Fatalf("expected absolute location, got %q", skill.Location)
+	}
+}
+
+func TestParseSkillMetadata_NoFrontmatterUsesFallbacks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "demo", "SKILL.md")
+	skill, ok, err := ParseSkillMetadata(path, "demo", []byte("plain markdown"))
+	if err != nil || !ok {
+		t.Fatalf("ParseSkillMetadata() ok=%v err=%v", ok, err)
+	}
+	if skill.Name != "demo" || skill.Description != "demo" {
+		t.Fatalf("unexpected skill: %#v", skill)
+	}
+}
+
+func TestParseSkillMetadata_EmptySkipped(t *testing.T) {
+	_, ok, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte(" \n\t"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected empty skill to be skipped")
+	}
+}
+
+func TestParseSkillMetadata_InvalidYAML(t *testing.T) {
+	_, _, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte("---\nname: [\n---\nBody"))
+	if err == nil {
+		t.Fatal("expected YAML parse error")
+	}
+}
+
+func TestParseSkillMetadata_MissingFieldsFallback(t *testing.T) {
+	skill, ok, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte("---\nother: field\n---\nBody"))
+	if err != nil || !ok {
+		t.Fatalf("ParseSkillMetadata() ok=%v err=%v", ok, err)
+	}
+	if skill.Name != "demo" || skill.Description != "demo" {
+		t.Fatalf("expected fallbacks, got %#v", skill)
+	}
+}

--- a/internal/skills/parse_test.go
+++ b/internal/skills/parse_test.go
@@ -2,17 +2,15 @@ package skills
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestParseSkillMetadata_WithFrontmatter(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "demo", "SKILL.md")
-	skill, ok, err := ParseSkillMetadata(path, "demo", []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"))
+	skill, err := ParseSkillMetadata(path, []byte("---\nname: demo\ndescription: Demo skill\n---\nBody"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if !ok {
-		t.Fatal("expected skill to load")
 	}
 	if skill.Name != "demo" || skill.Description != "Demo skill" {
 		t.Fatalf("unexpected skill: %#v", skill)
@@ -22,40 +20,56 @@ func TestParseSkillMetadata_WithFrontmatter(t *testing.T) {
 	}
 }
 
-func TestParseSkillMetadata_NoFrontmatterUsesFallbacks(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "demo", "SKILL.md")
-	skill, ok, err := ParseSkillMetadata(path, "demo", []byte("plain markdown"))
-	if err != nil || !ok {
-		t.Fatalf("ParseSkillMetadata() ok=%v err=%v", ok, err)
-	}
-	if skill.Name != "demo" || skill.Description != "demo" {
-		t.Fatalf("unexpected skill: %#v", skill)
-	}
-}
-
-func TestParseSkillMetadata_EmptySkipped(t *testing.T) {
-	_, ok, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte(" \n\t"))
+func TestParseSkillMetadata_NameDifferentFromDirIsAllowed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "any-dir", "SKILL.md")
+	skill, err := ParseSkillMetadata(path, []byte("---\nname: real-name\ndescription: Demo skill\n---\nBody"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if ok {
-		t.Fatal("expected empty skill to be skipped")
+	if skill.Name != "real-name" {
+		t.Fatalf("expected frontmatter name to win, got %q", skill.Name)
+	}
+}
+
+func TestParseSkillMetadata_NoFrontmatterErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "demo", "SKILL.md")
+	_, err := ParseSkillMetadata(path, []byte("plain markdown"))
+	if err == nil || !strings.Contains(err.Error(), "frontmatter") {
+		t.Fatalf("expected frontmatter error, got %v", err)
+	}
+}
+
+func TestParseSkillMetadata_EmptyErrors(t *testing.T) {
+	_, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), []byte(" \n\t"))
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty error, got %v", err)
 	}
 }
 
 func TestParseSkillMetadata_InvalidYAML(t *testing.T) {
-	_, _, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte("---\nname: [\n---\nBody"))
+	_, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), []byte("---\nname: [\n---\nBody"))
 	if err == nil {
 		t.Fatal("expected YAML parse error")
 	}
 }
 
-func TestParseSkillMetadata_MissingFieldsFallback(t *testing.T) {
-	skill, ok, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), "demo", []byte("---\nother: field\n---\nBody"))
-	if err != nil || !ok {
-		t.Fatalf("ParseSkillMetadata() ok=%v err=%v", ok, err)
+func TestParseSkillMetadata_MissingNameErrors(t *testing.T) {
+	_, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), []byte("---\ndescription: Demo skill\n---\nBody"))
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("expected missing name error, got %v", err)
 	}
-	if skill.Name != "demo" || skill.Description != "demo" {
-		t.Fatalf("expected fallbacks, got %#v", skill)
+}
+
+func TestParseSkillMetadata_MissingDescriptionErrors(t *testing.T) {
+	_, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), []byte("---\nname: demo\n---\nBody"))
+	if err == nil || !strings.Contains(err.Error(), "description") {
+		t.Fatalf("expected missing description error, got %v", err)
+	}
+}
+
+func TestParseSkillMetadata_BlankFieldsError(t *testing.T) {
+	_, err := ParseSkillMetadata(filepath.Join(t.TempDir(), "SKILL.md"), []byte("---\nname: demo\ndescription: \"   \"\n---\nBody"))
+	if err == nil || !strings.Contains(err.Error(), "description") {
+		t.Fatalf("expected blank description error, got %v", err)
 	}
 }

--- a/providers/registry.yaml
+++ b/providers/registry.yaml
@@ -5,7 +5,7 @@ providers:
       - id: claude-opus-4-7
         name: Claude Opus 4.7
         context_window: 1000000
-        thinking_efforts: ["low", "medium", "high", "max", "xhigh"]
+        thinking_efforts: ["low", "medium", "high", "max"]
       - id: claude-opus-4-6
         name: Claude Opus 4.6
         context_window: 1000000
@@ -49,6 +49,10 @@ providers:
         name: GPT-5.4
         context_window: 256000
         thinking_efforts: ["none", "low", "medium", "high", "xhigh"]
+      - id: gpt-5.4-mini
+        name: GPT-5.4 Mini
+        context_window: 256000
+        thinking_efforts: ["none", "low", "medium", "high", "xhigh"]
       - id: gpt-5.3-codex
         name: GPT-5.3 Codex
         context_window: 256000
@@ -60,11 +64,16 @@ providers:
       - id: gemini-3.1-pro-preview
         name: Gemini 3.1 Pro
         context_window: 1048576
-        thinking_efforts: ["off", "low", "medium", "high"]
+        thinking_efforts: ["low", "medium", "high"]
+      - id: gemini-3.1-flash-lite-preview
+        name: Gemini 3.1 Flash-Lite
+        context_window: 1048576
+        thinking_efforts: ["minimal", "low", "medium", "high"]
       - id: gemini-3-flash-preview
         name: Gemini 3 Flash
         context_window: 1048576
-        thinking_efforts: ["off", "low", "medium", "high"]
+        thinking_efforts: ["minimal", "low", "medium", "high"]
+
   - id: moonshotai
     name: Moonshot AI
     models:
@@ -90,6 +99,10 @@ providers:
         thinking_efforts: ["enabled", "disabled"]
       - id: glm-5
         name: GLM-5
+        context_window: 200000
+        thinking_efforts: ["enabled", "disabled"]
+      - id: glm-5-turbo
+        name: GLM-5 Turbo
         context_window: 200000
         thinking_efforts: ["enabled", "disabled"]
 


### PR DESCRIPTION
## What does this PR do?

- Make YAML frontmatter with name/description mandatory in SKILL.md                   
- Use frontmatter name as skill identity instead of directory name                    
- Add \$ARGUMENTS and positional \$1-\$9 substitution in activation messages          
- Deduplicate skills by frontmatter name with warning on collision                    
- Update system prompt wording for tool memory guidance                               
- Rename git-commit skill to commit in frontmatter

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New tool
- [ ] New provider or model
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] `go test ./...` passes
- [x] `go mod tidy` has been run
- [x] New behavior is covered by tests where it makes sense
- [ ] For new providers: entry added to `providers/registry.yaml` with correct `context_window`