### PR TITLE
feat(cli): add keen run headless command

### DIFF
--- a/.ai-interactions/tasks/issue-40/output-1_keen-run-plan.md
+++ b/.ai-interactions/tasks/issue-40/output-1_keen-run-plan.md
@@ -1,0 +1,349 @@
+# Plan: Add Benchmark-First `keen run`
+
+## Goal
+
+Add a simple non-interactive `keen run` command so Keen can be benchmarked against `opencode run` without PTY-driving the REPL.
+
+The first version should be benchmark-scoped, additive, and low-risk. It should reuse Keen's existing session, context, tool, and turn-memory behavior instead of creating a new agent architecture.
+
+## Non-Goals
+
+- Do not replace or refactor the REPL.
+- Do not build a full interactive or TUI-less product surface yet.
+- Do not implement `--continue`, `--fork`, session picker behavior, or slash commands.
+- Do not persist provider-specific `pendingState`.
+- Do not support cross-process recovery of incomplete provider tool loops.
+- Do not change existing session projection or context-management behavior.
+- Do not change tool implementations or REPL permission behavior.
+
+## Command Shape
+
+Initial CLI:
+
+```sh
+keen run [--session <session-id>] [--format text|json] <message...>
+```
+
+Behavior:
+
+- Without `--session`, create a new Keen session.
+- With `--session`, load that existing session and rebuild the conversation from its transcript.
+- Read piped stdin when present.
+- If both args and stdin are present, join them with a newline.
+- Default output is final assistant text only.
+- JSON output emits one final JSON object, not streaming JSONL.
+
+Suggested JSON output:
+
+```json
+{
+  "session_id": "keen-session-id",
+  "opencode_session_id": "keen-session-id-without-hyphens",
+  "text": "assistant response",
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "reasoning_tokens": 0,
+    "total_tokens": 0,
+    "cached_tokens": 0
+  }
+}
+```
+
+`opencode_session_id` should match the value Keen sends in the `x-opencode-session` header for OpenCode Go, currently the local session ID with hyphens removed.
+
+## Implementation Location
+
+Use a small headless runner inside the existing `repl` package:
+
+```text
+internal/cli/repl/headless_run.go
+```
+
+This is intentionally pragmatic. The behavior needed for `keen run` already lives in package-private REPL helpers:
+
+- `newReplSessionState`
+- `buildAssistantTurnEvent`
+- `cloneStreamSegments`
+- `newTurnMemoryAccumulator`
+- `StreamHandler`
+- diff event handling types
+
+Keeping the first pass in `internal/cli/repl` avoids premature extraction and avoids exporting internal details solely for a benchmark command.
+
+Add the Cobra subcommand in:
+
+```text
+internal/cli/cmd/root.go
+```
+
+## Headless Runner Flow
+
+High-level call chain:
+
+```text
+keen run
+  -> repl.RunHeadless(...)
+  -> AppState.StreamChat(...)
+  -> llmClient.StreamChat(...)
+```
+
+Do not call `llmClient.StreamChat` directly. `AppState.StreamChat` is the right layer because it adds Keen's system prompt, skills catalog, message history, and registered tools.
+
+Flow:
+
+1. Load provider registry and resolved config using the same root-command setup path.
+2. Create `llm.NewClient(cfg)`.
+3. Create `appstate.New(client, workingDir)`.
+4. Create an auto-approving REPL permission requester.
+5. Create `tooling.NewDiffEmitter()`.
+6. Call `tooling.SetupToolRegistry(workingDir, appState, permissionRequester, diffEmitter)`.
+7. Create `newReplSessionState(workingDir)`.
+8. If `--session` is provided:
+   - find the matching summary from `sessions.listSessions()`
+   - `sessions.load(summary)`
+   - rebuild context with `session.BuildConversation(loaded.Events)`
+   - call `appState.ReplaceMessages(...)`
+9. Append the user message to session storage.
+10. Append the user message to `appState`.
+11. Start the stream with `AppState.StreamChat(ctx, cfg, llm.StreamOptions{SessionID: sessions.currentID()})`.
+12. Consume LLM events and diff requests until done/error/incomplete.
+13. Persist the assistant turn with turn memory.
+14. Print final text or JSON.
+
+## Conversation Handling Across Commands
+
+`AppState` is in-memory, so every `keen run --session <id>` invocation must rebuild it from session storage before sending the next prompt.
+
+Use the same projection the REPL uses for session resume:
+
+```go
+appState.ReplaceMessages(session.BuildConversation(loaded.Events))
+```
+
+This preserves Keen's current conservative context behavior:
+
+- includes prior user messages
+- includes assistant messages
+- includes assistant `TurnMemory`
+- respects compaction replacement events
+- does not replay raw tool traces into future LLM context
+
+## Stream Handling
+
+Reuse `StreamHandler` as a turn accumulator, not as a UI renderer.
+
+Create it with no markdown renderer:
+
+```go
+handler := NewStreamHandler(nil)
+handler.Start(eventCh, "")
+handler.showThinking = false
+```
+
+Feed stream events into the same methods the REPL uses:
+
+```go
+case llm.StreamEventTypeChunk:
+    handler.HandleChunk(event.Content)
+
+case llm.StreamEventTypeReasoningChunk:
+    handler.HandleReasoningChunk(event.Content)
+
+case llm.StreamEventTypeToolStart:
+    if event.ToolCall.Name == "bash" {
+        command, _ := event.ToolCall.Input["command"].(string)
+        summary, _ := event.ToolCall.Input["summary"].(string)
+        handler.HandleBashStart(command, summary)
+    } else {
+        handler.HandleToolStart(event.ToolCall)
+    }
+
+case llm.StreamEventTypeToolEnd:
+    turnMemory.RecordToolEnd(event.ToolCall)
+    if event.ToolCall.Name == "bash" {
+        handler.HandleBashEnd(event.ToolCall)
+    } else {
+        handler.HandleToolEnd(event.ToolCall)
+    }
+
+case llm.StreamEventTypeUsage:
+    lastUsage = event.Usage
+
+case llm.StreamEventTypeRetry:
+    handler.RewindForRetry()
+```
+
+On done, snapshot segments before resetting the handler:
+
+```go
+segments := cloneStreamSegments(handler.segments)
+_, response := handler.HandleDone()
+
+assistant := llm.Message{
+    Role:       llm.RoleAssistant,
+    Content:    response,
+    TurnMemory: turnMemory.Build(),
+}
+
+appState.AppendMessage(assistant)
+sessions.appendAssistantTurn(segments, assistant, false, "")
+```
+
+Optional cleanup after the first pass: add a small `StreamHandler.Finish()` helper that returns the final response and resets state without rendering transcript lines.
+
+## Permission Policy
+
+Headless benchmark mode should skip the interactive permission flow entirely.
+
+Keep `tooling.SetupToolRegistry` and all tool constructor signatures unchanged. Add an auto-approve mode to the existing REPL permission requester:
+
+```go
+func NewAutoApproveRequester() *Requester {
+    r := NewRequester()
+    r.autoApprove = true
+    return r
+}
+
+func (r *Requester) RequestPermission(ctx context.Context, toolName, path, resolvedPath string, isDangerous bool) (bool, error) {
+    if r.autoApprove {
+        return true, nil
+    }
+
+    // Existing interactive request path stays unchanged.
+}
+```
+
+Then `keen run` can keep using the current registry API:
+
+```go
+permissionRequester := permissions.NewAutoApproveRequester()
+tooling.SetupToolRegistry(workingDir, appState, permissionRequester, diffEmitter)
+```
+
+This keeps REPL permission behavior unchanged while making `keen run` independent of permission channels. In auto-approve mode, `RequestPermission` returns before creating a `Request`, writing to `requestChan`, or waiting for a response.
+
+This skips user approval prompts, including dangerous bash-command approval. It does not bypass hard filesystem policy unless we intentionally change the guard. `filesystem.Guard` should still block denied paths such as ignored files, system paths, and hidden home directories. For benchmarking, keeping hard policy blocks is safer and keeps behavior closer to the existing tool contract.
+
+## Diff Handling
+
+`write_file` and `edit_file` emit diffs before permission approval. The existing `DiffEmitter` blocks until its `Done` channel is closed, so the headless loop must drain diff requests:
+
+```go
+case diffReq := <-diffEmitter.GetDiffChan():
+    handler.HandleDiff(diffReq.Lines)
+    close(diffReq.Done)
+```
+
+Skipping this will deadlock file edits.
+
+## Incomplete Turns
+
+Do not persist provider-specific `pendingState` in this first version.
+
+Current pending state lives inside the provider client instance. That works in the REPL because the same process and `llmClient` survive after an incomplete turn. `keen run` starts a fresh process each time, so that state would be lost.
+
+For benchmark mode, treat `StreamEventTypeIncomplete` as a failed run:
+
+- persist partial transcript if useful for debugging
+- print an error
+- exit non-zero
+- do not expect the next `keen run --session` to recover it
+
+When resuming a session, optionally reject sessions whose last assistant turn has an error or interruption:
+
+```text
+cannot resume incomplete headless session
+```
+
+This is simpler and more honest for benchmarking than silently comparing a degraded recovery path.
+
+## Root Command Wiring
+
+`internal/cli/cmd/root.go` should add a `run` subcommand while preserving the existing default REPL behavior.
+
+Suggested structure:
+
+```go
+root := &cobra.Command{... existing REPL RunE ...}
+root.AddCommand(newRunCommand(version))
+```
+
+`newRunCommand` should reuse the same config-loading logic as the root command. If duplication becomes annoying, extract a small helper like:
+
+```go
+func loadRuntimeConfig() (*providers.Registry, *config.Loader, *config.GlobalConfig, *config.ResolvedConfig, bool, error)
+```
+
+Keep that helper mechanical; do not refactor unrelated root command behavior.
+
+## Stdin Handling
+
+Use standard input only when it is piped. Since `golang.org/x/term` is already present indirectly, either use it or a simple file stat check.
+
+Behavior:
+
+```text
+args only      -> prompt = joined args
+stdin only     -> prompt = stdin
+args + stdin   -> prompt = joined args + "\n" + stdin
+empty prompt   -> usage error
+```
+
+## Tests
+
+Focused tests only:
+
+1. Headless run creates a new session and persists user + assistant events using a fake LLM client.
+2. Headless run with `--session` rebuilds conversation with `session.BuildConversation`.
+3. Permission-pending tool path is auto-approved in headless mode.
+4. Dangerous bash permission request is auto-approved in headless mode.
+5. Diff requests are drained and do not block edits.
+6. Incomplete event returns a non-zero/error result.
+7. CLI prompt assembly handles args, stdin, and args + stdin.
+
+Avoid real provider calls in tests.
+
+## Verification
+
+After implementation:
+
+```sh
+gofmt -w <modified-go-files>
+go mod tidy
+go test ./...
+```
+
+Manual smoke tests:
+
+```sh
+keen run --format json "Say hello"
+keen run "Inspect the repo and summarize it in one sentence"
+keen run --session <session-id> "Now list the most relevant files you saw"
+echo "Say hello from stdin" | keen run --format json
+```
+
+For OpenCode Go benchmark attribution, confirm the JSON output's `opencode_session_id` matches the session shown in the OpenCode web usage interface.
+
+## Expected Minimal File Changes
+
+Likely files:
+
+```text
+internal/cli/cmd/root.go
+internal/cli/repl/headless_run.go
+internal/cli/repl/headless_run_test.go
+internal/cli/cmd/root_test.go
+```
+
+Optional:
+
+```text
+internal/cli/repl/stream_handler.go
+```
+
+Only add a `Finish()` helper if it materially simplifies the headless runner.
+
+## Why This Approach
+
+This path keeps the benchmark command isolated and additive while still exercising the same context-management behavior as the REPL. It avoids brittle PTY automation, avoids broad refactors, and avoids turning `keen run` into a full product surface before the benchmark need is proven.

--- a/.ai-interactions/tasks/issue-40/prompt-1_keen-run.md
+++ b/.ai-interactions/tasks/issue-40/prompt-1_keen-run.md
@@ -1,0 +1,11 @@
+## Supporting `keen run` Command
+
+1. I want to compare Keen Code against OpenCode. I have an OpenCode Go subscription. That subscription can run both on OpenCode CLI and Keen Code. Since Keen Code takes a conservative approach in context management, I expect to see significant token usage savings in Keen compared to OpenCode CLI. My experiments show the same. But how can I compare these two reliably? I also have opencode repo in `../opencode`.
+2. Since both tools run on repl, how can we automatically test them?
+3. Would `keen run` directly invoke StreamChat function?
+4. Is opencode run synchronous? How does it output to stdin?
+5. Okay explore keen. Then suggest me the most simple approach for supporting `keen run` commands. It should be simple, reuse existing code, avoid extra work as much as possible. I prefer isolating benchmark path if that makes things simpler and easier to work on.
+6. Do we have to change anything that impacts existing functionalities?
+7. In this flow, how is the conversation handled in subsequent turn? Right now, appstate stores the conversation and passes it to LLM every time a user sends a new message. But appstate is in memory. When we will run with `keen run`, we execute one command, receive a response, and execute another command. But who would enrich LLM context with the converstaion so far?
+8. Ok based on our conversation, let's create a concrete plan and save in `.ai-interactions/tasks/issue-40` as `output-1_keen-run-plan.md`
+9. Let's work on the plan.

--- a/bench/benchmark-plan.md
+++ b/bench/benchmark-plan.md
@@ -1,0 +1,383 @@
+# Keen vs OpenCode Benchmark Plan
+
+## Goal
+
+Build an initial black-box benchmark that compares Keen against OpenCode on the same target repository, using the public CLI for both tools:
+
+- Keen: `keen run`
+- OpenCode: `opencode run`
+
+The first benchmark only executes tasks and saves normalized outputs. Usage and cost will be checked manually in the OpenCode dashboard using session IDs.
+
+## Requirements
+
+- Benchmark target repository must be configurable.
+- Benchmark harness lives under `bench/` in the `keen-code` repository.
+- Use `keen` and `opencode` from `PATH`.
+- Create worktrees from the target repository's `main` branch.
+- Use two separate worktrees for the benchmark:
+  - one for Keen
+  - one for OpenCode
+- Worktrees are created under `bench/worktrees/<run_id>/`.
+- Fail if `bench/worktrees/<run_id>/` or `bench/results/<run_id>/` already exists.
+- Delete worktrees when the benchmark finishes.
+- Run tasks sequentially.
+- For now, use 5 read-only multi-turn tasks.
+- Each task should contain 5 to 10 user turns.
+- Task definitions will live in `bench/tasks.json`.
+- Each task produces one combined normalized output file containing both Keen and OpenCode results.
+- Raw CLI outputs should also be saved for debugging parser or normalization issues.
+- Multi-turn state must be preserved by passing the session ID returned by each tool into later turns.
+- No permission prompt should be required.
+- If either tool requests permission, the benchmark should fail that task/run.
+- Print all distinct Keen and OpenCode session IDs at the end.
+- OpenCode session IDs are especially important because the usage dashboard is checked by session ID.
+
+## CLI Configuration
+
+### Keen
+
+Keen uses the local Keen config for provider/model selection.
+
+Command shape:
+
+```bash
+keen run --format json "prompt"
+keen run --format json --session "$KEEN_SESSION_ID" "next prompt"
+```
+
+Keen does not currently have a run id or title argument. The benchmark run id will be recorded only in the benchmark output metadata for Keen.
+
+### OpenCode
+
+OpenCode should use:
+
+```bash
+opencode run --format json --thinking --model opencode-go/kimi-k2.6 --title "$TASK_RUN_ID" "prompt"
+opencode run --format json --thinking --model opencode-go/kimi-k2.6 --session "$OPENCODE_SESSION_ID" "next prompt"
+```
+
+`--thinking` is supported by OpenCode. In non-interactive mode it defaults to false, so the benchmark must pass it explicitly.
+
+OpenCode emits newline-delimited JSON events, not a single JSON object. The harness must parse the stream and normalize it into one turn result.
+
+## Directory Layout
+
+```text
+bench/
+  benchmark-plan.md
+  run.sh
+  tasks.json
+  results/
+    <run_id>/
+      summary.json
+      sessions.txt
+      task-01.json
+      task-02.json
+      task-03.json
+      task-04.json
+      task-05.json
+      raw/
+        task-01/
+          keen-turn-01.json
+          keen-turn-02.json
+          opencode-turn-01.ndjson
+          opencode-turn-02.ndjson
+  worktrees/
+    <run_id>/
+      keen/
+      opencode/
+```
+
+`bench/worktrees/<run_id>/` should be removed after the benchmark finishes, even if a task fails. `bench/results/<run_id>/` should remain.
+
+## Command Shape
+
+Initial script interface:
+
+```bash
+bench/run.sh --repo /path/to/target/repo --run-id bench-20260512-001
+```
+
+Optional flags that are useful but not required in the first version:
+
+```bash
+bench/run.sh \
+  --repo /path/to/target/repo \
+  --run-id bench-20260512-001 \
+  --tasks bench/tasks.json \
+  --opencode-model opencode-go/kimi-k2.6
+```
+
+Defaults:
+
+- `--tasks`: `bench/tasks.json`
+- `--opencode-model`: `opencode-go/kimi-k2.6`
+
+## Task File
+
+`bench/tasks.json` should contain fixed benchmark tasks.
+
+Proposed schema:
+
+```json
+{
+  "tasks": [
+    {
+      "id": "task-01",
+      "title": "Map CLI command flow",
+      "turns": [
+        "Find the entry point for the CLI and summarize how commands are registered.",
+        "Now identify where configuration is loaded and explain the data flow.",
+        "Which files would need to change to add a new read-only command?"
+      ]
+    }
+  ]
+}
+```
+
+Rules for tasks:
+
+- Read-only only.
+- Avoid requests to edit files, run formatters, commit changes, install dependencies, or change config.
+- Prefer repository-understanding tasks that require navigating code.
+- Make Keen and OpenCode answer the same prompts in the same order.
+- Keep prompts deterministic and avoid asking for subjective recommendations unless the code context is enough.
+
+## Worktree Setup
+
+For a target repo `/path/to/repo` and run id `bench-20260512-001`:
+
+1. Verify `/path/to/repo` is a git repo.
+2. Verify `main` exists.
+3. Fail if target repo has no `main` branch.
+4. Fail if `bench/results/bench-20260512-001` exists.
+5. Fail if `bench/worktrees/bench-20260512-001` exists.
+6. Create:
+
+```bash
+git -C /path/to/repo worktree add /path/to/keen-code/bench/worktrees/bench-20260512-001/keen main
+git -C /path/to/repo worktree add /path/to/keen-code/bench/worktrees/bench-20260512-001/opencode main
+```
+
+7. Record the checked-out commit for each worktree.
+
+If the target repo already has `main` checked out and git refuses to add duplicate worktrees for the same branch, the implementation should create detached worktrees from `main`:
+
+```bash
+git -C /path/to/repo worktree add --detach <path> main
+```
+
+Detached worktrees are acceptable because benchmark tasks are read-only.
+
+## Execution Flow
+
+For each task:
+
+1. Start with empty Keen and OpenCode session IDs.
+2. For each turn:
+   1. Run Keen in the Keen worktree.
+   2. Parse Keen output.
+   3. Store Keen session ID from the first turn and pass it to later turns.
+   4. Run OpenCode in the OpenCode worktree.
+   5. Parse OpenCode NDJSON.
+   6. Store OpenCode session ID from the first event and pass it to later turns.
+   7. Save raw outputs for both tools.
+   8. Append normalized turn results.
+   9. Check `git status --short` in both worktrees.
+   10. If either worktree is dirty, mark the task as failed because the task was expected to be read-only.
+3. Write `bench/results/<run_id>/<task_id>.json`.
+
+Sequential ordering should be:
+
+```text
+task-01 turn-01 keen
+task-01 turn-01 opencode
+task-01 turn-02 keen
+task-01 turn-02 opencode
+...
+task-02 turn-01 keen
+task-02 turn-01 opencode
+```
+
+## Normalized Output
+
+Each task output should contain both tools:
+
+```json
+{
+  "run_id": "bench-20260512-001",
+  "task": {
+    "id": "task-01",
+    "title": "Map CLI command flow"
+  },
+  "target_repo": {
+    "path": "/path/to/repo",
+    "ref": "main",
+    "keen_commit": "abc123",
+    "opencode_commit": "abc123"
+  },
+  "tools": {
+    "keen": {
+      "session_id": "uuid-or-id",
+      "turns": []
+    },
+    "opencode": {
+      "session_id": "ses_...",
+      "turns": []
+    }
+  }
+}
+```
+
+Each turn should include:
+
+```json
+{
+  "turn": 1,
+  "prompt": "Find the entry point...",
+  "command": ["keen", "run", "--format", "json", "..."],
+  "cwd": "/path/to/worktree",
+  "started_at": "2026-05-12T10:00:00Z",
+  "finished_at": "2026-05-12T10:00:10Z",
+  "duration_ms": 10000,
+  "exit_code": 0,
+  "session_id": "session-id",
+  "text": "assistant response",
+  "usage": {
+    "input": 0,
+    "output": 0,
+    "reasoning": 0,
+    "cache_read": 0,
+    "cache_write": 0,
+    "total": 0,
+    "cost": 0
+  },
+  "raw_output": "raw/task-01/keen-turn-01.json",
+  "stderr": "",
+  "dirty_status": ""
+}
+```
+
+Usage fields may be zero or omitted if the tool does not provide them reliably. Dashboard usage remains the source of truth for cost comparison.
+
+## Keen Normalization
+
+Expected Keen output is one JSON object.
+
+Extract:
+
+- `session_id`
+- `text`
+- usage fields when present
+
+If Keen emits invalid JSON, mark the turn failed and save stdout/stderr.
+
+## OpenCode Normalization
+
+OpenCode emits NDJSON events.
+
+Extract:
+
+- `sessionID` from the first event that has it.
+- Assistant text from events where `type == "text"` and `part.text` exists.
+- Usage from all events where `type == "step_finish"` and `part.tokens` exists.
+- Cost from all `step_finish.part.cost` values.
+
+Usage mapping:
+
+- `part.tokens.input` -> `input`
+- `part.tokens.output` -> `output`
+- `part.tokens.reasoning` -> `reasoning`
+- `part.tokens.cache.read` -> `cache_read`
+- `part.tokens.cache.write` -> `cache_write`
+- `part.tokens.total` -> `total`
+
+If OpenCode emits a permission event, fail:
+
+- `type == "permission.asked"`
+
+If OpenCode emits `session.error`, fail the turn and include the error in normalized output.
+
+## Failure Handling
+
+The benchmark should fail fast for setup errors:
+
+- missing `keen`
+- missing `opencode`
+- missing `jq` if the shell implementation depends on it
+- target repo is not a git repo
+- target repo has no `main`
+- result directory already exists
+- worktree directory already exists
+- invalid tasks file
+
+During task execution:
+
+- If one tool fails a turn, record the failure in the task output.
+- Stop the current task.
+- Continue to cleanup.
+- The first implementation may stop the whole benchmark after a failed task to keep behavior simple.
+
+Worktree cleanup should happen in all cases.
+
+## Session ID Summary
+
+At the end, print distinct session IDs in a copyable format:
+
+```text
+Benchmark run: bench-20260512-001
+
+Keen sessions:
+task-01  <keen-session-id>
+task-02  <keen-session-id>
+
+OpenCode sessions:
+task-01  ses_...
+task-02  ses_...
+
+Results:
+bench/results/bench-20260512-001
+```
+
+Also save the same information to:
+
+```text
+bench/results/<run_id>/sessions.txt
+```
+
+## Initial Implementation Choice
+
+Use a shell script for the first version:
+
+- It is the smallest implementation.
+- It directly exercises the real CLI commands.
+- It avoids adding product code or Go package structure.
+- It is easy to replace later with Go if the benchmark grows.
+
+The shell script can use `jq` for:
+
+- validating `tasks.json`
+- parsing Keen JSON
+- collapsing OpenCode NDJSON
+- writing normalized JSON
+
+## Verification
+
+Manual smoke test:
+
+```bash
+bench/run.sh --repo /path/to/repo --run-id bench-smoke-001
+```
+
+Verify:
+
+- Worktrees are created from `main`.
+- Worktrees are removed after completion.
+- `bench/results/<run_id>/task-*.json` files exist.
+- Raw outputs exist.
+- `sessions.txt` contains all Keen and OpenCode session IDs.
+- OpenCode session IDs match sessions visible in the OpenCode dashboard.
+- Dirty worktree status is empty for both tools after every turn.
+
+Because the benchmark uses real LLM calls, automated tests should focus on parser helpers if the implementation grows. The first shell version can be verified with one short smoke task before running all 5 tasks.

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -42,17 +42,25 @@ func NewRootCommand(version string) *cobra.Command {
 func newRunCommand() *cobra.Command {
 	var sessionID string
 	var format string
+	var providerID string
+	var modelID string
 
 	runCmd := &cobra.Command{
 		Use:   "run [flags] <message...>",
 		Short: "Run one non-interactive Keen turn",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, _, _, resolvedCfg, needsSetup, err := loadRootRuntime()
+			_, _, globalCfg, resolvedCfg, _, err := loadRootRuntime()
 			if err != nil {
 				return err
 			}
-			if needsSetup {
+			if err := applyRunOverrides(globalCfg, resolvedCfg, providerID, modelID); err != nil {
+				return err
+			}
+			if resolvedCfg.Provider == "" {
+				return fmt.Errorf("LLM client not initialized. Run keen to configure a provider")
+			}
+			if resolvedCfg.AuthMode == config.AuthModeOAuth && !keenauth.NewOAuthManager(nil).HasCredential(resolvedCfg.Provider) {
 				return fmt.Errorf("LLM client not initialized. Run keen to configure a provider")
 			}
 
@@ -91,6 +99,8 @@ func newRunCommand() *cobra.Command {
 	}
 	runCmd.Flags().StringVar(&sessionID, "session", "", "resume an existing Keen session")
 	runCmd.Flags().StringVar(&format, "format", repl.HeadlessFormatText, "output format: text or json")
+	runCmd.Flags().StringVar(&providerID, "provider", "", "provider to use for this run")
+	runCmd.Flags().StringVar(&modelID, "model", "", "model to use for this run")
 	return runCmd
 }
 
@@ -127,6 +137,26 @@ func loadRootRuntime() (*providers.Registry, *config.Loader, *config.GlobalConfi
 	}
 	needsSetup := resolvedCfg.AuthMode == config.AuthModeOAuth && !keenauth.NewOAuthManager(nil).HasCredential(globalCfg.ActiveProvider)
 	return registry, loader, globalCfg, resolvedCfg, needsSetup, nil
+}
+
+func applyRunOverrides(globalCfg *config.GlobalConfig, resolvedCfg *config.ResolvedConfig, providerID string, modelID string) error {
+	if providerID != "" {
+		providerCfg, ok := globalCfg.GetProviderConfig(providerID)
+		if !ok {
+			return fmt.Errorf("provider %q is not configured", providerID)
+		}
+		resolvedCfg.Provider = providerID
+		resolvedCfg.APIKey = providerCfg.APIKey
+		resolvedCfg.BaseURL = providerCfg.BaseURL
+		resolvedCfg.AuthMode = config.AuthModeForProvider(providerID)
+		if modelID == "" && len(providerCfg.Models) > 0 {
+			resolvedCfg.Model = providerCfg.Models[0]
+		}
+	}
+	if modelID != "" {
+		resolvedCfg.Model = modelID
+	}
+	return nil
 }
 
 func buildRunPrompt(args []string, stdin string) string {

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	keenauth "github.com/user/keen-code/internal/auth"
 	"github.com/user/keen-code/internal/cli/repl"
 	"github.com/user/keen-code/internal/config"
+	"github.com/user/keen-code/internal/llm"
 	"github.com/user/keen-code/providers"
 )
 
@@ -17,44 +21,10 @@ func NewRootCommand(version string) *cobra.Command {
 		Short: "Keen - A coding agent CLI",
 		Long:  `Keen is a terminal-based coding agent that provides AI-assisted code editing.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			registry, err := providers.Load()
+			registry, loader, globalCfg, resolvedCfg, needsSetup, err := loadRootRuntime()
 			if err != nil {
-				return fmt.Errorf("failed to load provider registry: %w", err)
+				return err
 			}
-			loader := config.NewLoader()
-			globalCfg, err := loader.Load()
-			if err != nil {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
-
-			var resolvedCfg *config.ResolvedConfig
-			needsSetup := false
-
-			if globalCfg.ActiveProvider == "" {
-				needsSetup = true
-				resolvedCfg = &config.ResolvedConfig{}
-			} else {
-				_, ok := registry.GetProvider(globalCfg.ActiveProvider)
-				if !ok {
-					return fmt.Errorf("configured provider %q not found in registry", globalCfg.ActiveProvider)
-				}
-				providerCfg, ok := globalCfg.GetProviderConfig(globalCfg.ActiveProvider)
-				if !ok {
-					return fmt.Errorf("failed to get provider config for %q", globalCfg.ActiveProvider)
-				}
-				resolvedCfg = &config.ResolvedConfig{
-					Provider:       globalCfg.ActiveProvider,
-					Model:          globalCfg.ActiveModel,
-					APIKey:         providerCfg.APIKey,
-					ThinkingEffort: globalCfg.ThinkingEffort,
-					BaseURL:        providerCfg.BaseURL,
-					AuthMode:       config.AuthModeForProvider(globalCfg.ActiveProvider),
-				}
-				if resolvedCfg.AuthMode == config.AuthModeOAuth && !keenauth.NewOAuthManager(nil).HasCredential(globalCfg.ActiveProvider) {
-					needsSetup = true
-				}
-			}
-
 			wd, err := os.Getwd()
 			if err != nil {
 				wd = "."
@@ -65,5 +35,117 @@ func NewRootCommand(version string) *cobra.Command {
 	}
 
 	cmd.Version = version
+	cmd.AddCommand(newRunCommand())
 	return cmd
+}
+
+func newRunCommand() *cobra.Command {
+	var sessionID string
+	var format string
+
+	runCmd := &cobra.Command{
+		Use:   "run [flags] <message...>",
+		Short: "Run one non-interactive Keen turn",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, _, _, resolvedCfg, needsSetup, err := loadRootRuntime()
+			if err != nil {
+				return err
+			}
+			if needsSetup {
+				return fmt.Errorf("LLM client not initialized. Run keen to configure a provider")
+			}
+
+			stdin := ""
+			if shouldReadStdin(os.Stdin) {
+				data, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return fmt.Errorf("read stdin: %w", err)
+				}
+				stdin = string(data)
+			}
+			prompt := buildRunPrompt(args, stdin)
+			if prompt == "" {
+				return fmt.Errorf("prompt is required")
+			}
+
+			wd, err := os.Getwd()
+			if err != nil {
+				wd = "."
+			}
+			client, err := llm.NewClient(resolvedCfg)
+			if err != nil {
+				return err
+			}
+			_, err = repl.RunHeadless(context.Background(), repl.HeadlessRunOptions{
+				WorkingDir: wd,
+				Config:     resolvedCfg,
+				Client:     client,
+				SessionID:  sessionID,
+				Prompt:     prompt,
+				Format:     format,
+				Out:        cmd.OutOrStdout(),
+			})
+			return err
+		},
+	}
+	runCmd.Flags().StringVar(&sessionID, "session", "", "resume an existing Keen session")
+	runCmd.Flags().StringVar(&format, "format", repl.HeadlessFormatText, "output format: text or json")
+	return runCmd
+}
+
+func loadRootRuntime() (*providers.Registry, *config.Loader, *config.GlobalConfig, *config.ResolvedConfig, bool, error) {
+	registry, err := providers.Load()
+	if err != nil {
+		return nil, nil, nil, nil, false, fmt.Errorf("failed to load provider registry: %w", err)
+	}
+	loader := config.NewLoader()
+	globalCfg, err := loader.Load()
+	if err != nil {
+		return nil, nil, nil, nil, false, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if globalCfg.ActiveProvider == "" {
+		return registry, loader, globalCfg, &config.ResolvedConfig{}, true, nil
+	}
+
+	_, ok := registry.GetProvider(globalCfg.ActiveProvider)
+	if !ok {
+		return nil, nil, nil, nil, false, fmt.Errorf("configured provider %q not found in registry", globalCfg.ActiveProvider)
+	}
+	providerCfg, ok := globalCfg.GetProviderConfig(globalCfg.ActiveProvider)
+	if !ok {
+		return nil, nil, nil, nil, false, fmt.Errorf("failed to get provider config for %q", globalCfg.ActiveProvider)
+	}
+	resolvedCfg := &config.ResolvedConfig{
+		Provider:       globalCfg.ActiveProvider,
+		Model:          globalCfg.ActiveModel,
+		APIKey:         providerCfg.APIKey,
+		ThinkingEffort: globalCfg.ThinkingEffort,
+		BaseURL:        providerCfg.BaseURL,
+		AuthMode:       config.AuthModeForProvider(globalCfg.ActiveProvider),
+	}
+	needsSetup := resolvedCfg.AuthMode == config.AuthModeOAuth && !keenauth.NewOAuthManager(nil).HasCredential(globalCfg.ActiveProvider)
+	return registry, loader, globalCfg, resolvedCfg, needsSetup, nil
+}
+
+func buildRunPrompt(args []string, stdin string) string {
+	argText := strings.TrimSpace(strings.Join(args, " "))
+	stdin = strings.TrimSpace(stdin)
+	switch {
+	case argText != "" && stdin != "":
+		return argText + "\n" + stdin
+	case argText != "":
+		return argText
+	default:
+		return stdin
+	}
+}
+
+func shouldReadStdin(stdin *os.File) bool {
+	info, err := stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice == 0
 }

--- a/internal/cli/cmd/root_test.go
+++ b/internal/cli/cmd/root_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"testing"
+
+	"github.com/user/keen-code/internal/config"
 )
 
 func TestNewRootCommand(t *testing.T) {
@@ -41,6 +43,87 @@ func TestNewRootCommand_HasRunCommand(t *testing.T) {
 	}
 	if runCmd == nil || runCmd.Name() != "run" {
 		t.Fatalf("expected run command, got %#v", runCmd)
+	}
+}
+
+func TestNewRootCommand_RunCommandHasModelProviderFlags(t *testing.T) {
+	cmd := NewRootCommand("0.1.0")
+
+	runCmd, _, err := cmd.Find([]string{"run"})
+	if err != nil {
+		t.Fatalf("Find(run) error = %v", err)
+	}
+
+	for _, name := range []string{"model", "provider"} {
+		if runCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected run command to have --%s flag", name)
+		}
+	}
+}
+
+func TestApplyRunOverrides(t *testing.T) {
+	globalCfg := &config.GlobalConfig{
+		Providers: map[string]config.ProviderConfig{
+			config.ProviderAnthropic: {
+				APIKey:  "anthropic-key",
+				Models:  []string{"claude-3"},
+				BaseURL: "https://anthropic.example",
+			},
+			config.ProviderOpenCodeGo: {
+				APIKey:  "opencode-key",
+				Models:  []string{"kimi-k2.6"},
+				BaseURL: "https://opencode.example",
+			},
+		},
+	}
+	resolvedCfg := &config.ResolvedConfig{
+		Provider: config.ProviderAnthropic,
+		APIKey:   "anthropic-key",
+		Model:    "claude-3",
+		BaseURL:  "https://anthropic.example",
+		AuthMode: config.AuthModeAPIKey,
+	}
+
+	err := applyRunOverrides(globalCfg, resolvedCfg, config.ProviderOpenCodeGo, "qwen3.6-plus")
+	if err != nil {
+		t.Fatalf("applyRunOverrides() error = %v", err)
+	}
+
+	if resolvedCfg.Provider != config.ProviderOpenCodeGo {
+		t.Fatalf("Provider = %q, want %q", resolvedCfg.Provider, config.ProviderOpenCodeGo)
+	}
+	if resolvedCfg.APIKey != "opencode-key" {
+		t.Fatalf("APIKey = %q, want opencode-key", resolvedCfg.APIKey)
+	}
+	if resolvedCfg.BaseURL != "https://opencode.example" {
+		t.Fatalf("BaseURL = %q, want https://opencode.example", resolvedCfg.BaseURL)
+	}
+	if resolvedCfg.Model != "qwen3.6-plus" {
+		t.Fatalf("Model = %q, want qwen3.6-plus", resolvedCfg.Model)
+	}
+}
+
+func TestApplyRunOverrides_ProviderUsesFirstConfiguredModel(t *testing.T) {
+	globalCfg := &config.GlobalConfig{
+		Providers: map[string]config.ProviderConfig{
+			config.ProviderOpenCodeGo: {
+				APIKey: "opencode-key",
+				Models: []string{"kimi-k2.6"},
+			},
+		},
+	}
+	resolvedCfg := &config.ResolvedConfig{
+		Provider: config.ProviderAnthropic,
+		Model:    "claude-3",
+	}
+
+	err := applyRunOverrides(globalCfg, resolvedCfg, config.ProviderOpenCodeGo, "")
+	if err != nil {
+		t.Fatalf("applyRunOverrides() error = %v", err)
+	}
+
+	if resolvedCfg.Model != "kimi-k2.6" {
+		t.Fatalf("Model = %q, want kimi-k2.6", resolvedCfg.Model)
 	}
 }
 

--- a/internal/cli/cmd/root_test.go
+++ b/internal/cli/cmd/root_test.go
@@ -31,3 +31,38 @@ func TestNewRootCommand_DifferentVersion(t *testing.T) {
 		t.Errorf("command Version = %q, want '1.2.3'", cmd.Version)
 	}
 }
+
+func TestNewRootCommand_HasRunCommand(t *testing.T) {
+	cmd := NewRootCommand("0.1.0")
+
+	runCmd, _, err := cmd.Find([]string{"run"})
+	if err != nil {
+		t.Fatalf("Find(run) error = %v", err)
+	}
+	if runCmd == nil || runCmd.Name() != "run" {
+		t.Fatalf("expected run command, got %#v", runCmd)
+	}
+}
+
+func TestBuildRunPrompt(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		stdin string
+		want  string
+	}{
+		{name: "args only", args: []string{"hello", "there"}, want: "hello there"},
+		{name: "stdin only", stdin: " from stdin\n", want: "from stdin"},
+		{name: "args and stdin", args: []string{"hello"}, stdin: "from stdin\n", want: "hello\nfrom stdin"},
+		{name: "empty", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRunPrompt(tt.args, tt.stdin)
+			if got != tt.want {
+				t.Fatalf("buildRunPrompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/repl/headless_run.go
+++ b/internal/cli/repl/headless_run.go
@@ -1,0 +1,240 @@
+package repl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	replappstate "github.com/user/keen-code/internal/cli/repl/appstate"
+	replpermissions "github.com/user/keen-code/internal/cli/repl/permissions"
+	repltooling "github.com/user/keen-code/internal/cli/repl/tooling"
+	"github.com/user/keen-code/internal/config"
+	"github.com/user/keen-code/internal/llm"
+	"github.com/user/keen-code/internal/session"
+)
+
+const (
+	HeadlessFormatText = "text"
+	HeadlessFormatJSON = "json"
+)
+
+type HeadlessRunOptions struct {
+	WorkingDir string
+	Config     *config.ResolvedConfig
+	Client     llm.LLMClient
+	SessionID  string
+	Prompt     string
+	Format     string
+	Out        io.Writer
+}
+
+type HeadlessRunResult struct {
+	SessionID         string         `json:"session_id"`
+	OpenCodeSessionID string         `json:"opencode_session_id"`
+	Text              string         `json:"text"`
+	Usage             *headlessUsage `json:"usage,omitempty"`
+}
+
+type headlessUsage struct {
+	InputTokens     int `json:"input_tokens"`
+	OutputTokens    int `json:"output_tokens"`
+	ReasoningTokens int `json:"reasoning_tokens"`
+	TotalTokens     int `json:"total_tokens"`
+	CachedTokens    int `json:"cached_tokens"`
+}
+
+func RunHeadless(ctx context.Context, opts HeadlessRunOptions) (*HeadlessRunResult, error) {
+	prompt := strings.TrimSpace(opts.Prompt)
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+	if opts.Client == nil {
+		return nil, fmt.Errorf("LLM client not initialized")
+	}
+	format := opts.Format
+	if format == "" {
+		format = HeadlessFormatText
+	}
+	if format != HeadlessFormatText && format != HeadlessFormatJSON {
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+
+	appState := replappstate.New(opts.Client, opts.WorkingDir)
+	permissionRequester := replpermissions.NewAutoApproveRequester()
+	diffEmitter := repltooling.NewDiffEmitter()
+	repltooling.SetupToolRegistry(opts.WorkingDir, appState, permissionRequester, diffEmitter)
+
+	sessions := newReplSessionState(opts.WorkingDir)
+	if sessions == nil {
+		return nil, fmt.Errorf("session store unavailable")
+	}
+	if opts.SessionID != "" {
+		loaded, err := loadHeadlessSession(sessions, opts.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		appState.ReplaceMessages(session.BuildConversation(loaded.Events))
+	}
+
+	if err := sessions.appendUserMessage(prompt); err != nil {
+		return nil, err
+	}
+	appState.AddMessage(llm.RoleUser, prompt)
+
+	eventCh, err := appState.StreamChat(ctx, opts.Config, llm.StreamOptions{SessionID: sessions.currentID()})
+	if err != nil {
+		return nil, err
+	}
+	if eventCh == nil {
+		return nil, fmt.Errorf("LLM client not initialized")
+	}
+
+	handler := NewStreamHandler(nil)
+	handler.workingDir = opts.WorkingDir
+	handler.showThinking = false
+	handler.Start(eventCh, "")
+	turnMemory := newTurnMemoryAccumulator()
+
+	var lastUsage *llm.TokenUsage
+	for {
+		select {
+		case diffReq := <-diffEmitter.GetDiffChan():
+			handler.HandleDiff(diffReq.Lines)
+			close(diffReq.Done)
+		case event, ok := <-eventCh:
+			if !ok {
+				return finishHeadlessRun(opts.Out, format, sessions, handler, turnMemory, lastUsage)
+			}
+			switch event.Type {
+			case llm.StreamEventTypeChunk:
+				handler.HandleChunk(event.Content)
+			case llm.StreamEventTypeReasoningChunk:
+				handler.HandleReasoningChunk(event.Content)
+			case llm.StreamEventTypeToolStart:
+				handleHeadlessToolStart(handler, event.ToolCall)
+			case llm.StreamEventTypeToolEnd:
+				turnMemory.RecordToolEnd(cloneToolCallWithRelativePath(event.ToolCall, opts.WorkingDir))
+				handleHeadlessToolEnd(handler, event.ToolCall)
+			case llm.StreamEventTypeUsage:
+				lastUsage = event.Usage
+			case llm.StreamEventTypeRetry:
+				handler.RewindForRetry()
+			case llm.StreamEventTypeDone:
+				return finishHeadlessRun(opts.Out, format, sessions, handler, turnMemory, lastUsage)
+			case llm.StreamEventTypeIncomplete:
+				return failHeadlessRun(sessions, handler, turnMemory, event.Error)
+			case llm.StreamEventTypeError:
+				return failHeadlessRun(sessions, handler, turnMemory, event.Error)
+			}
+		case <-ctx.Done():
+			return failHeadlessRun(sessions, handler, turnMemory, ctx.Err())
+		}
+	}
+}
+
+func loadHeadlessSession(sessions *replSessionState, sessionID string) (*session.LoadedSession, error) {
+	summaries, err := sessions.listSessions()
+	if err != nil {
+		return nil, err
+	}
+	for _, summary := range summaries {
+		if summary.ID == sessionID {
+			return sessions.load(summary)
+		}
+	}
+	return nil, fmt.Errorf("session %q not found", sessionID)
+}
+
+func handleHeadlessToolStart(handler *StreamHandler, toolCall *llm.ToolCall) {
+	if toolCall == nil {
+		return
+	}
+	if toolCall.Name == "bash" {
+		command, _ := toolCall.Input["command"].(string)
+		summary, _ := toolCall.Input["summary"].(string)
+		handler.HandleBashStart(command, summary)
+		return
+	}
+	handler.HandleToolStart(toolCall)
+}
+
+func handleHeadlessToolEnd(handler *StreamHandler, toolCall *llm.ToolCall) {
+	if toolCall == nil {
+		return
+	}
+	if toolCall.Name == "bash" {
+		handler.HandleBashEnd(toolCall)
+		return
+	}
+	handler.HandleToolEnd(toolCall)
+}
+
+func finishHeadlessRun(out io.Writer, format string, sessions *replSessionState, handler *StreamHandler, turnMemory *turnMemoryAccumulator, usage *llm.TokenUsage) (*HeadlessRunResult, error) {
+	segments := cloneStreamSegments(handler.segments)
+	_, response := handler.HandleDone()
+	assistantMessage := llm.Message{
+		Role:       llm.RoleAssistant,
+		Content:    response,
+		TurnMemory: turnMemory.Build(),
+	}
+	if err := sessions.appendAssistantTurn(segments, assistantMessage, false, ""); err != nil {
+		return nil, err
+	}
+
+	result := &HeadlessRunResult{
+		SessionID:         sessions.currentID(),
+		OpenCodeSessionID: strings.ReplaceAll(sessions.currentID(), "-", ""),
+		Text:              response,
+		Usage:             cloneHeadlessUsage(usage),
+	}
+	return result, writeHeadlessResult(out, format, result)
+}
+
+func failHeadlessRun(sessions *replSessionState, handler *StreamHandler, turnMemory *turnMemoryAccumulator, err error) (*HeadlessRunResult, error) {
+	if err == nil {
+		err = fmt.Errorf("LLM stream incomplete")
+	}
+	segments := cloneStreamSegments(handler.segments)
+	partialResponse := handler.GetResponse()
+	_, errMsg := handler.HandleError(err)
+	assistantMessage := llm.Message{
+		Role:       llm.RoleAssistant,
+		Content:    partialResponse,
+		TurnMemory: turnMemory.Build(),
+	}
+	_ = sessions.appendAssistantTurn(segments, assistantMessage, false, errMsg)
+	return nil, err
+}
+
+func cloneHeadlessUsage(usage *llm.TokenUsage) *headlessUsage {
+	if usage == nil {
+		return nil
+	}
+	return &headlessUsage{
+		InputTokens:     usage.InputTokens,
+		OutputTokens:    usage.OutputTokens,
+		ReasoningTokens: usage.ReasoningTokens,
+		TotalTokens:     usage.TotalTokens,
+		CachedTokens:    usage.CachedTokens,
+	}
+}
+
+func writeHeadlessResult(out io.Writer, format string, result *HeadlessRunResult) error {
+	if out == nil {
+		return nil
+	}
+	switch format {
+	case HeadlessFormatJSON:
+		encoder := json.NewEncoder(out)
+		return encoder.Encode(result)
+	default:
+		if result.Text == "" {
+			_, err := fmt.Fprintln(out)
+			return err
+		}
+		_, err := fmt.Fprintln(out, result.Text)
+		return err
+	}
+}

--- a/internal/cli/repl/headless_run_test.go
+++ b/internal/cli/repl/headless_run_test.go
@@ -1,0 +1,217 @@
+package repl
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/user/keen-code/internal/config"
+	"github.com/user/keen-code/internal/llm"
+	"github.com/user/keen-code/internal/session"
+	"github.com/user/keen-code/internal/tools"
+)
+
+type recordingHeadlessClient struct {
+	events   []llm.StreamEvent
+	messages [][]llm.Message
+	opts     [][]llm.StreamOptions
+}
+
+func (c *recordingHeadlessClient) StreamChat(ctx context.Context, messages []llm.Message, toolRegistry *tools.Registry, opts ...llm.StreamOptions) (<-chan llm.StreamEvent, error) {
+	c.messages = append(c.messages, llm.CloneMessages(messages))
+	c.opts = append(c.opts, append([]llm.StreamOptions(nil), opts...))
+	ch := make(chan llm.StreamEvent, len(c.events))
+	go func() {
+		defer close(ch)
+		for _, event := range c.events {
+			select {
+			case ch <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+func (c *recordingHeadlessClient) Reset() {}
+
+func TestRunHeadless_CreatesSessionAndWritesText(t *testing.T) {
+	workingDir := setupHeadlessTestHome(t)
+	client := &recordingHeadlessClient{events: []llm.StreamEvent{
+		{Type: llm.StreamEventTypeChunk, Content: "hello"},
+		{Type: llm.StreamEventTypeUsage, Usage: &llm.TokenUsage{InputTokens: 3, OutputTokens: 2, TotalTokens: 5}},
+		{Type: llm.StreamEventTypeDone},
+	}}
+	var out bytes.Buffer
+
+	result, err := RunHeadless(context.Background(), HeadlessRunOptions{
+		WorkingDir: workingDir,
+		Config:     headlessTestConfig(),
+		Client:     client,
+		Prompt:     "say hi",
+		Out:        &out,
+	})
+	if err != nil {
+		t.Fatalf("RunHeadless() error = %v", err)
+	}
+	if result.SessionID == "" {
+		t.Fatal("expected session id")
+	}
+	if result.OpenCodeSessionID == "" || result.OpenCodeSessionID == result.SessionID {
+		t.Fatalf("expected hyphen-stripped OpenCode session id, got %q from %q", result.OpenCodeSessionID, result.SessionID)
+	}
+	if result.Text != "hello" || out.String() != "hello\n" {
+		t.Fatalf("unexpected output result=%q out=%q", result.Text, out.String())
+	}
+	if result.Usage == nil || result.Usage.InputTokens != 3 || result.Usage.OutputTokens != 2 || result.Usage.TotalTokens != 5 {
+		t.Fatalf("unexpected usage: %#v", result.Usage)
+	}
+
+	events := loadOnlyHeadlessSessionEvents(t, workingDir)
+	if len(events) != 3 {
+		t.Fatalf("expected session started, user, assistant events; got %d", len(events))
+	}
+	if events[1].UserMessage == nil || events[1].UserMessage.Content != "say hi" {
+		t.Fatalf("unexpected user event: %#v", events[1].UserMessage)
+	}
+	if events[2].AssistantTurn == nil || events[2].AssistantTurn.Message != "hello" {
+		t.Fatalf("unexpected assistant event: %#v", events[2].AssistantTurn)
+	}
+}
+
+func TestRunHeadless_ResumesSessionConversation(t *testing.T) {
+	workingDir := setupHeadlessTestHome(t)
+	firstClient := &recordingHeadlessClient{events: []llm.StreamEvent{
+		{Type: llm.StreamEventTypeChunk, Content: "first response"},
+		{Type: llm.StreamEventTypeDone},
+	}}
+
+	first, err := RunHeadless(context.Background(), HeadlessRunOptions{
+		WorkingDir: workingDir,
+		Config:     headlessTestConfig(),
+		Client:     firstClient,
+		Prompt:     "first prompt",
+	})
+	if err != nil {
+		t.Fatalf("first RunHeadless() error = %v", err)
+	}
+
+	secondClient := &recordingHeadlessClient{events: []llm.StreamEvent{
+		{Type: llm.StreamEventTypeChunk, Content: "second response"},
+		{Type: llm.StreamEventTypeDone},
+	}}
+	_, err = RunHeadless(context.Background(), HeadlessRunOptions{
+		WorkingDir: workingDir,
+		Config:     headlessTestConfig(),
+		Client:     secondClient,
+		SessionID:  first.SessionID,
+		Prompt:     "second prompt",
+	})
+	if err != nil {
+		t.Fatalf("second RunHeadless() error = %v", err)
+	}
+	if len(secondClient.messages) != 1 {
+		t.Fatalf("expected one StreamChat call, got %d", len(secondClient.messages))
+	}
+	got := messageContents(secondClient.messages[0])
+	want := []string{"first prompt", "first response", "second prompt"}
+	if !containsOrderedSuffix(got, want) {
+		t.Fatalf("expected conversation suffix %#v, got %#v", want, got)
+	}
+	if len(secondClient.opts) != 1 || len(secondClient.opts[0]) != 1 || secondClient.opts[0][0].SessionID != first.SessionID {
+		t.Fatalf("expected session stream option %q, got %#v", first.SessionID, secondClient.opts)
+	}
+}
+
+func TestRunHeadless_WritesJSON(t *testing.T) {
+	workingDir := setupHeadlessTestHome(t)
+	client := &recordingHeadlessClient{events: []llm.StreamEvent{
+		{Type: llm.StreamEventTypeChunk, Content: "json response"},
+		{Type: llm.StreamEventTypeDone},
+	}}
+	var out bytes.Buffer
+
+	_, err := RunHeadless(context.Background(), HeadlessRunOptions{
+		WorkingDir: workingDir,
+		Config:     headlessTestConfig(),
+		Client:     client,
+		Prompt:     "prompt",
+		Format:     HeadlessFormatJSON,
+		Out:        &out,
+	})
+	if err != nil {
+		t.Fatalf("RunHeadless() error = %v", err)
+	}
+
+	var decoded HeadlessRunResult
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode json output: %v", err)
+	}
+	if decoded.SessionID == "" || decoded.Text != "json response" {
+		t.Fatalf("unexpected json result: %#v", decoded)
+	}
+}
+
+func setupHeadlessTestHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	workingDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(workingDir, 0755); err != nil {
+		t.Fatalf("create working dir: %v", err)
+	}
+	return workingDir
+}
+
+func headlessTestConfig() *config.ResolvedConfig {
+	return &config.ResolvedConfig{
+		Provider: config.ProviderOpenAI,
+		APIKey:   "test-key",
+		Model:    "test-model",
+	}
+}
+
+func loadOnlyHeadlessSessionEvents(t *testing.T, workingDir string) []session.Event {
+	t.Helper()
+	store, err := session.NewStore(workingDir)
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	summaries, err := store.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected one session, got %d", len(summaries))
+	}
+	loaded, err := store.Load(summaries[0])
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	return loaded.Events
+}
+
+func messageContents(messages []llm.Message) []string {
+	contents := make([]string, 0, len(messages))
+	for _, message := range messages {
+		contents = append(contents, message.Content)
+	}
+	return contents
+}
+
+func containsOrderedSuffix(got []string, want []string) bool {
+	if len(got) < len(want) {
+		return false
+	}
+	got = got[len(got)-len(want):]
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/repl/permissions/requester.go
+++ b/internal/cli/repl/permissions/requester.go
@@ -36,6 +36,7 @@ type Requester struct {
 	requestChan         chan *Request
 	pending             *Request
 	sessionAllowedTools map[string]bool
+	autoApprove         bool
 }
 
 func NewRequester() *Requester {
@@ -45,7 +46,17 @@ func NewRequester() *Requester {
 	}
 }
 
+func NewAutoApproveRequester() *Requester {
+	r := NewRequester()
+	r.autoApprove = true
+	return r
+}
+
 func (r *Requester) RequestPermission(ctx context.Context, toolName, path, resolvedPath string, isDangerous bool) (bool, error) {
+	if r.autoApprove {
+		return true, nil
+	}
+
 	if !isDangerous && r.sessionAllowedTools[toolName] {
 		return true, nil
 	}

--- a/internal/cli/repl/permissions/requester_test.go
+++ b/internal/cli/repl/permissions/requester_test.go
@@ -1,0 +1,27 @@
+package permissions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAutoApproveRequester_AllowsWithoutRequest(t *testing.T) {
+	requester := NewAutoApproveRequester()
+
+	allowed, err := requester.RequestPermission(context.Background(), "bash", "rm -rf tmp", "", true)
+	if err != nil {
+		t.Fatalf("RequestPermission() error = %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected auto-approved permission")
+	}
+	if requester.HasPendingRequest() {
+		t.Fatal("expected no pending request")
+	}
+
+	select {
+	case req := <-requester.GetRequestChan():
+		t.Fatalf("expected no permission request, got %#v", req)
+	default:
+	}
+}

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -473,9 +473,11 @@ func (c *OpenAICompatibleClient) StreamChat(
 				eventCh <- StreamEvent{
 					Type: StreamEventTypeUsage,
 					Usage: &TokenUsage{
-						InputTokens:  int(usage.PromptTokens),
-						OutputTokens: int(usage.CompletionTokens),
-						TotalTokens:  int(usage.TotalTokens),
+						InputTokens:     int(usage.PromptTokens),
+						OutputTokens:    int(usage.CompletionTokens),
+						TotalTokens:     int(usage.TotalTokens),
+						CachedTokens:    int(usage.PromptTokensDetails.CachedTokens),
+						ReasoningTokens: int(usage.CompletionTokensDetails.ReasoningTokens),
 					},
 				}
 			}

--- a/internal/llm/openai_codex.go
+++ b/internal/llm/openai_codex.go
@@ -120,6 +120,7 @@ func (c *OpenAICodexClient) StreamChat(ctx context.Context, messages []Message, 
 						OutputTokens:    int(completed.Usage.OutputTokens),
 						TotalTokens:     int(completed.Usage.TotalTokens),
 						ReasoningTokens: int(completed.Usage.OutputTokensDetails.ReasoningTokens),
+						CachedTokens:    int(completed.Usage.InputTokensDetails.CachedTokens),
 					},
 				}
 			}

--- a/internal/llm/openai_responses.go
+++ b/internal/llm/openai_responses.go
@@ -196,6 +196,7 @@ func (c *OpenAIResponsesClient) StreamChat(
 						OutputTokens:    int(completed.Usage.OutputTokens),
 						TotalTokens:     int(completed.Usage.TotalTokens),
 						ReasoningTokens: int(completed.Usage.OutputTokensDetails.ReasoningTokens),
+						CachedTokens:    int(completed.Usage.InputTokensDetails.CachedTokens),
 					},
 				}
 			}


### PR DESCRIPTION


## What does this PR do?

- Add non-interactive `keen run` subcommand with text and json output
- Add headless runner in internal/cli/repl that reuses REPL session and stream handling
- Add auto-approve permission requester for benchmark mode
- Support session resume via --session flag
- Include cached and reasoning tokens in usage reporting for OpenAI providers
- Add tests for headless run, CLI prompt building, and auto-approve permissions
- Add benchmark plan documentation under bench/

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New tool
- [ ] New provider or model
- [ ] Refactor
- [ ] Other:

## Checklist

- [x] `go test ./...` passes
- [x] `go mod tidy` has been run
- [x] New behavior is covered by tests where it makes sense
- [ ] For new providers: entry added to `providers/registry.yaml` with correct `context_window`